### PR TITLE
fix(appimage): cambiar ruta de instalación a ~/.local/bin/

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Output: `dist/appimage/CapyDeploy_Hub.AppImage` and `CapyDeploy_Agent.AppImage`
 ### Auto-Installation
 
 When you run the AppImage for the first time, it will prompt to install:
-- Moves to `~/Applications/`
+- Moves to `~/.local/bin/`
 - Creates desktop entry in `~/.local/share/applications/`
 - Copies icon to `~/.local/share/icons/`
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -92,7 +92,7 @@ cd apps/agent && ./build.sh</code></pre>
             <h4 class="text-lg font-semibold mb-2">Auto-Installation</h4>
             <p class="text-slate-400 mb-3">Double-click the AppImage and it will prompt to install:</p>
             <ul class="text-slate-400 text-sm space-y-1 mb-4">
-              <li>• Moves to <code class="text-capy-400">~/Applications/</code></li>
+              <li>• Moves to <code class="text-capy-400">~/.local/bin/</code></li>
               <li>• Creates desktop entry in <code class="text-capy-400">~/.local/share/applications/</code></li>
               <li>• Copies icon to <code class="text-capy-400">~/.local/share/icons/</code></li>
             </ul>

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -127,7 +127,7 @@ HERE=${SELF%/*}
 APPIMAGE="${APPIMAGE:-$SELF}"
 APP_NAME="BINARY_NAME"
 DESKTOP_NAME="DESKTOP_FILE"
-INSTALL_DIR="$HOME/Applications"
+INSTALL_DIR="$HOME/.local/bin"
 DESKTOP_DIR="$HOME/.local/share/applications"
 ICON_DIR="$HOME/.local/share/icons"
 


### PR DESCRIPTION
## Resumen
- Cambia la ruta de instalación de `~/Applications/` a `~/.local/bin/`
- `~/.local/bin/` es más estándar en Linux y está en `$PATH` por defecto

## Archivos modificados
- `scripts/build-appimage.sh`
- `README.md`
- `docs/install.html`

Closes #37