### PR TITLE
test: agregar suite de tests automatizados

### DIFF
--- a/apps/agents/desktop/auth/auth_test.go
+++ b/apps/agents/desktop/auth/auth_test.go
@@ -1,0 +1,361 @@
+package auth
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// mockStorage is an in-memory implementation of the Storage interface for testing.
+type mockStorage struct {
+	mu   sync.Mutex
+	hubs []AuthorizedHub
+}
+
+func newMockStorage() *mockStorage {
+	return &mockStorage{}
+}
+
+func (m *mockStorage) GetAuthorizedHubs() []AuthorizedHub {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]AuthorizedHub, len(m.hubs))
+	copy(result, m.hubs)
+	return result
+}
+
+func (m *mockStorage) AddAuthorizedHub(hub AuthorizedHub) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, h := range m.hubs {
+		if h.ID == hub.ID {
+			m.hubs[i] = hub
+			return nil
+		}
+	}
+	m.hubs = append(m.hubs, hub)
+	return nil
+}
+
+func (m *mockStorage) RemoveAuthorizedHub(hubID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, h := range m.hubs {
+		if h.ID == hubID {
+			m.hubs = append(m.hubs[:i], m.hubs[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (m *mockStorage) UpdateHubLastSeen(hubID string, lastSeen time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, h := range m.hubs {
+		if h.ID == hubID {
+			m.hubs[i].LastSeen = lastSeen
+			return nil
+		}
+	}
+	return nil
+}
+
+func (m *mockStorage) Save() error {
+	return nil
+}
+
+// --- Tests ---
+
+func TestGenerateCode(t *testing.T) {
+	mgr := NewManager(newMockStorage())
+
+	code, err := mgr.GenerateCode("hub-1", "Test Hub", "linux")
+	if err != nil {
+		t.Fatalf("GenerateCode() error = %v", err)
+	}
+
+	if len(code) != CodeLength {
+		t.Errorf("GenerateCode() code length = %d, want %d", len(code), CodeLength)
+	}
+
+	// Code should be all digits
+	for _, c := range code {
+		if c < '0' || c > '9' {
+			t.Errorf("GenerateCode() code contains non-digit: %c", c)
+		}
+	}
+}
+
+func TestGenerateCode_Callback(t *testing.T) {
+	mgr := NewManager(newMockStorage())
+
+	var callbackCode string
+	var callbackExpiry time.Duration
+	mgr.SetPairingCodeCallback(func(code string, expiresIn time.Duration) {
+		callbackCode = code
+		callbackExpiry = expiresIn
+	})
+
+	code, err := mgr.GenerateCode("hub-1", "Test Hub", "linux")
+	if err != nil {
+		t.Fatalf("GenerateCode() error = %v", err)
+	}
+
+	if callbackCode != code {
+		t.Errorf("callback code = %q, want %q", callbackCode, code)
+	}
+	if callbackExpiry != CodeExpiry {
+		t.Errorf("callback expiry = %v, want %v", callbackExpiry, CodeExpiry)
+	}
+}
+
+func TestValidateCode_Success(t *testing.T) {
+	store := newMockStorage()
+	mgr := NewManager(store)
+
+	code, err := mgr.GenerateCode("hub-1", "Test Hub", "linux")
+	if err != nil {
+		t.Fatalf("GenerateCode() error = %v", err)
+	}
+
+	token, err := mgr.ValidateCode("hub-1", "Test Hub", code)
+	if err != nil {
+		t.Fatalf("ValidateCode() error = %v", err)
+	}
+
+	if token == "" {
+		t.Error("ValidateCode() returned empty token")
+	}
+
+	// Hub should be in authorized list
+	hubs := store.GetAuthorizedHubs()
+	if len(hubs) != 1 {
+		t.Fatalf("expected 1 authorized hub, got %d", len(hubs))
+	}
+	if hubs[0].ID != "hub-1" {
+		t.Errorf("authorized hub ID = %q, want %q", hubs[0].ID, "hub-1")
+	}
+	if hubs[0].Platform != "linux" {
+		t.Errorf("authorized hub platform = %q, want %q", hubs[0].Platform, "linux")
+	}
+}
+
+func TestValidateCode_WrongCode(t *testing.T) {
+	mgr := NewManager(newMockStorage())
+
+	_, err := mgr.GenerateCode("hub-1", "Test Hub", "linux")
+	if err != nil {
+		t.Fatalf("GenerateCode() error = %v", err)
+	}
+
+	_, err = mgr.ValidateCode("hub-1", "Test Hub", "000000")
+	if err != ErrCodeInvalid {
+		t.Errorf("ValidateCode() error = %v, want %v", err, ErrCodeInvalid)
+	}
+}
+
+func TestValidateCode_WrongHubID(t *testing.T) {
+	mgr := NewManager(newMockStorage())
+
+	code, err := mgr.GenerateCode("hub-1", "Test Hub", "linux")
+	if err != nil {
+		t.Fatalf("GenerateCode() error = %v", err)
+	}
+
+	_, err = mgr.ValidateCode("hub-wrong", "Test Hub", code)
+	if err != ErrCodeInvalid {
+		t.Errorf("ValidateCode() error = %v, want %v", err, ErrCodeInvalid)
+	}
+}
+
+func TestValidateCode_Expired(t *testing.T) {
+	mgr := NewManager(newMockStorage())
+
+	code, err := mgr.GenerateCode("hub-1", "Test Hub", "linux")
+	if err != nil {
+		t.Fatalf("GenerateCode() error = %v", err)
+	}
+
+	// Force expiration by manipulating the pending pairing
+	mgr.mu.Lock()
+	mgr.pendingPairing.ExpiresAt = time.Now().Add(-1 * time.Second)
+	mgr.mu.Unlock()
+
+	_, err = mgr.ValidateCode("hub-1", "Test Hub", code)
+	if err != ErrCodeExpired {
+		t.Errorf("ValidateCode() error = %v, want %v", err, ErrCodeExpired)
+	}
+}
+
+func TestValidateCode_RateLimit(t *testing.T) {
+	mgr := NewManager(newMockStorage())
+
+	code, err := mgr.GenerateCode("hub-1", "Test Hub", "linux")
+	if err != nil {
+		t.Fatalf("GenerateCode() error = %v", err)
+	}
+
+	// Fail MaxFailedAttempts times
+	for i := 0; i < MaxFailedAttempts; i++ {
+		_, _ = mgr.ValidateCode("hub-1", "Test Hub", "wrong!")
+	}
+
+	// Next attempt should be rate limited even with correct code
+	_, err = mgr.ValidateCode("hub-1", "Test Hub", code)
+	if err != ErrRateLimited {
+		t.Errorf("ValidateCode() after rate limit error = %v, want %v", err, ErrRateLimited)
+	}
+}
+
+func TestValidateCode_NoPending(t *testing.T) {
+	mgr := NewManager(newMockStorage())
+
+	_, err := mgr.ValidateCode("hub-1", "Test Hub", "123456")
+	if err != ErrNoPendingPairing {
+		t.Errorf("ValidateCode() error = %v, want %v", err, ErrNoPendingPairing)
+	}
+}
+
+func TestValidateToken(t *testing.T) {
+	store := newMockStorage()
+	mgr := NewManager(store)
+
+	code, err := mgr.GenerateCode("hub-1", "Test Hub", "linux")
+	if err != nil {
+		t.Fatalf("GenerateCode() error = %v", err)
+	}
+
+	token, err := mgr.ValidateCode("hub-1", "Test Hub", code)
+	if err != nil {
+		t.Fatalf("ValidateCode() error = %v", err)
+	}
+
+	// Valid token
+	if !mgr.ValidateToken("hub-1", token) {
+		t.Error("ValidateToken() = false for valid token")
+	}
+
+	// Wrong token
+	if mgr.ValidateToken("hub-1", "bad-token") {
+		t.Error("ValidateToken() = true for invalid token")
+	}
+
+	// Wrong hub ID
+	if mgr.ValidateToken("hub-wrong", token) {
+		t.Error("ValidateToken() = true for wrong hub ID")
+	}
+}
+
+func TestIsHubAuthorized(t *testing.T) {
+	store := newMockStorage()
+	mgr := NewManager(store)
+
+	// Not authorized initially
+	if mgr.IsHubAuthorized("hub-1") {
+		t.Error("IsHubAuthorized() = true before pairing")
+	}
+
+	// Pair the hub
+	code, _ := mgr.GenerateCode("hub-1", "Test Hub", "linux")
+	_, _ = mgr.ValidateCode("hub-1", "Test Hub", code)
+
+	if !mgr.IsHubAuthorized("hub-1") {
+		t.Error("IsHubAuthorized() = false after pairing")
+	}
+}
+
+func TestRevokeHub(t *testing.T) {
+	store := newMockStorage()
+	mgr := NewManager(store)
+
+	// Pair first
+	code, _ := mgr.GenerateCode("hub-1", "Test Hub", "linux")
+	_, _ = mgr.ValidateCode("hub-1", "Test Hub", code)
+
+	if !mgr.IsHubAuthorized("hub-1") {
+		t.Fatal("hub should be authorized after pairing")
+	}
+
+	// Revoke
+	if err := mgr.RevokeHub("hub-1"); err != nil {
+		t.Fatalf("RevokeHub() error = %v", err)
+	}
+
+	if mgr.IsHubAuthorized("hub-1") {
+		t.Error("IsHubAuthorized() = true after revoke")
+	}
+}
+
+func TestGetPendingPairing(t *testing.T) {
+	mgr := NewManager(newMockStorage())
+
+	// No pending initially
+	if p := mgr.GetPendingPairing(); p != nil {
+		t.Error("GetPendingPairing() should be nil initially")
+	}
+
+	// Generate code
+	code, _ := mgr.GenerateCode("hub-1", "Test Hub", "linux")
+
+	p := mgr.GetPendingPairing()
+	if p == nil {
+		t.Fatal("GetPendingPairing() = nil after GenerateCode")
+	}
+	if p.Code != code {
+		t.Errorf("pending code = %q, want %q", p.Code, code)
+	}
+	if p.HubID != "hub-1" {
+		t.Errorf("pending HubID = %q, want %q", p.HubID, "hub-1")
+	}
+}
+
+func TestGetPendingPairing_Expired(t *testing.T) {
+	mgr := NewManager(newMockStorage())
+
+	_, _ = mgr.GenerateCode("hub-1", "Test Hub", "linux")
+
+	// Force expiration
+	mgr.mu.Lock()
+	mgr.pendingPairing.ExpiresAt = time.Now().Add(-1 * time.Second)
+	mgr.mu.Unlock()
+
+	if p := mgr.GetPendingPairing(); p != nil {
+		t.Error("GetPendingPairing() should be nil after expiration")
+	}
+}
+
+func TestCancelPendingPairing(t *testing.T) {
+	mgr := NewManager(newMockStorage())
+
+	_, _ = mgr.GenerateCode("hub-1", "Test Hub", "linux")
+
+	mgr.CancelPendingPairing()
+
+	if p := mgr.GetPendingPairing(); p != nil {
+		t.Error("GetPendingPairing() should be nil after cancel")
+	}
+}
+
+func TestGetAuthorizedHubs(t *testing.T) {
+	store := newMockStorage()
+	mgr := NewManager(store)
+
+	// Empty initially
+	hubs := mgr.GetAuthorizedHubs()
+	if len(hubs) != 0 {
+		t.Errorf("GetAuthorizedHubs() len = %d, want 0", len(hubs))
+	}
+
+	// Pair two hubs
+	code1, _ := mgr.GenerateCode("hub-1", "Hub One", "linux")
+	_, _ = mgr.ValidateCode("hub-1", "Hub One", code1)
+
+	code2, _ := mgr.GenerateCode("hub-2", "Hub Two", "windows")
+	_, _ = mgr.ValidateCode("hub-2", "Hub Two", code2)
+
+	hubs = mgr.GetAuthorizedHubs()
+	if len(hubs) != 2 {
+		t.Errorf("GetAuthorizedHubs() len = %d, want 2", len(hubs))
+	}
+}

--- a/apps/agents/desktop/config/config_test.go
+++ b/apps/agents/desktop/config/config_test.go
@@ -1,0 +1,288 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewManager(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	// Should have default values
+	if mgr.GetName() == "" {
+		t.Error("GetName() returned empty string")
+	}
+	if mgr.GetInstallPath() == "" {
+		t.Error("GetInstallPath() returned empty string")
+	}
+}
+
+func TestGetSetName(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if err := mgr.SetName("my-agent"); err != nil {
+		t.Fatalf("SetName() error = %v", err)
+	}
+
+	if got := mgr.GetName(); got != "my-agent" {
+		t.Errorf("GetName() = %q, want %q", got, "my-agent")
+	}
+}
+
+func TestGetSetInstallPath(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if err := mgr.SetInstallPath("/opt/games"); err != nil {
+		t.Fatalf("SetInstallPath() error = %v", err)
+	}
+
+	if got := mgr.GetInstallPath(); got != "/opt/games" {
+		t.Errorf("GetInstallPath() = %q, want %q", got, "/opt/games")
+	}
+}
+
+func TestAddAuthorizedHub(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	hub := AuthorizedHub{
+		ID:    "hub-1",
+		Name:  "Test Hub",
+		Token: "secret-token",
+	}
+
+	if err := mgr.AddAuthorizedHub(hub); err != nil {
+		t.Fatalf("AddAuthorizedHub() error = %v", err)
+	}
+
+	hubs := mgr.GetAuthorizedHubs()
+	if len(hubs) != 1 {
+		t.Fatalf("GetAuthorizedHubs() len = %d, want 1", len(hubs))
+	}
+	if hubs[0].ID != "hub-1" {
+		t.Errorf("hub.ID = %q, want %q", hubs[0].ID, "hub-1")
+	}
+}
+
+func TestAddAuthorizedHub_UpdateExisting(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	hub := AuthorizedHub{ID: "hub-1", Name: "Hub Old", Token: "token-old"}
+	mgr.AddAuthorizedHub(hub)
+
+	// Update with same ID
+	hub2 := AuthorizedHub{ID: "hub-1", Name: "Hub New", Token: "token-new"}
+	if err := mgr.AddAuthorizedHub(hub2); err != nil {
+		t.Fatalf("AddAuthorizedHub() update error = %v", err)
+	}
+
+	hubs := mgr.GetAuthorizedHubs()
+	if len(hubs) != 1 {
+		t.Fatalf("expected 1 hub after update, got %d", len(hubs))
+	}
+	if hubs[0].Name != "Hub New" {
+		t.Errorf("hub.Name = %q, want %q", hubs[0].Name, "Hub New")
+	}
+}
+
+func TestRemoveAuthorizedHub(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	mgr.AddAuthorizedHub(AuthorizedHub{ID: "hub-1", Name: "Hub 1"})
+	mgr.AddAuthorizedHub(AuthorizedHub{ID: "hub-2", Name: "Hub 2"})
+
+	if err := mgr.RemoveAuthorizedHub("hub-1"); err != nil {
+		t.Fatalf("RemoveAuthorizedHub() error = %v", err)
+	}
+
+	hubs := mgr.GetAuthorizedHubs()
+	if len(hubs) != 1 {
+		t.Fatalf("GetAuthorizedHubs() len = %d, want 1", len(hubs))
+	}
+	if hubs[0].ID != "hub-2" {
+		t.Errorf("remaining hub ID = %q, want %q", hubs[0].ID, "hub-2")
+	}
+}
+
+func TestRemoveAuthorizedHub_NotFound(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	// Removing non-existent hub should not error
+	if err := mgr.RemoveAuthorizedHub("nonexistent"); err != nil {
+		t.Errorf("RemoveAuthorizedHub() error = %v, want nil", err)
+	}
+}
+
+func TestSaveAndReload(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	mgr1, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	mgr1.SetName("persistent-agent")
+	mgr1.SetInstallPath("/data/games")
+	mgr1.AddAuthorizedHub(AuthorizedHub{ID: "hub-x", Name: "Hub X", Token: "tok"})
+
+	// Create a new manager that loads the saved config
+	mgr2, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() reload error = %v", err)
+	}
+
+	if got := mgr2.GetName(); got != "persistent-agent" {
+		t.Errorf("reloaded name = %q, want %q", got, "persistent-agent")
+	}
+	if got := mgr2.GetInstallPath(); got != "/data/games" {
+		t.Errorf("reloaded installPath = %q, want %q", got, "/data/games")
+	}
+	hubs := mgr2.GetAuthorizedHubs()
+	if len(hubs) != 1 || hubs[0].ID != "hub-x" {
+		t.Errorf("reloaded hubs = %v, want [{ID:hub-x}]", hubs)
+	}
+}
+
+func TestLoad_CorruptFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Write corrupt data to the config file
+	configDir := filepath.Join(tmpDir, "capydeploy-agent")
+	os.MkdirAll(configDir, 0755)
+	os.WriteFile(filepath.Join(configDir, "config.json"), []byte("{invalid json!"), 0600)
+
+	// Should fall back to defaults without error
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	// Should have default values (not empty)
+	if mgr.GetName() == "" {
+		t.Error("GetName() should have default value after corrupt config")
+	}
+}
+
+func TestGetConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	mgr.SetName("test-agent")
+
+	cfg := mgr.GetConfig()
+	if cfg.Name != "test-agent" {
+		t.Errorf("GetConfig().Name = %q, want %q", cfg.Name, "test-agent")
+	}
+}
+
+func TestUpdateHubLastSeen(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	mgr.AddAuthorizedHub(AuthorizedHub{ID: "hub-1", Name: "Hub"})
+
+	if err := mgr.UpdateHubLastSeen("hub-1", "2025-01-15T10:30:00Z"); err != nil {
+		t.Fatalf("UpdateHubLastSeen() error = %v", err)
+	}
+
+	hubs := mgr.GetAuthorizedHubs()
+	if len(hubs) != 1 || hubs[0].LastSeen != "2025-01-15T10:30:00Z" {
+		t.Errorf("hub LastSeen = %q, want %q", hubs[0].LastSeen, "2025-01-15T10:30:00Z")
+	}
+}
+
+func TestSave_FilePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	mgr.SetName("perm-test")
+
+	configPath := filepath.Join(tmpDir, "capydeploy-agent", "config.json")
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("config file not found: %v", err)
+	}
+
+	perm := info.Mode().Perm()
+	if perm != 0600 {
+		t.Errorf("config file permissions = %o, want 0600", perm)
+	}
+}
+
+func TestSave_ValidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	mgr.SetName("json-test")
+
+	configPath := filepath.Join(tmpDir, "capydeploy-agent", "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("config is not valid JSON: %v", err)
+	}
+
+	if cfg.Name != "json-test" {
+		t.Errorf("saved name = %q, want %q", cfg.Name, "json-test")
+	}
+}

--- a/apps/agents/desktop/server/server_test.go
+++ b/apps/agents/desktop/server/server_test.go
@@ -1,0 +1,269 @@
+package server
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/lobinuxsoft/capydeploy/pkg/protocol"
+	"github.com/lobinuxsoft/capydeploy/pkg/transfer"
+)
+
+func TestNew_Defaults(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv, err := New(Config{
+		Name:       "test-agent",
+		Platform:   "linux",
+		Version:    "0.1.0",
+		UploadPath: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if srv.id == "" {
+		t.Error("New() server ID is empty")
+	}
+
+	if srv.cfg.Name != "test-agent" {
+		t.Errorf("server name = %q, want %q", srv.cfg.Name, "test-agent")
+	}
+}
+
+func TestNew_StableID(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv1, _ := New(Config{Name: "agent-a", Platform: "linux", UploadPath: tmpDir})
+	srv2, _ := New(Config{Name: "agent-a", Platform: "linux", UploadPath: tmpDir})
+	srv3, _ := New(Config{Name: "agent-b", Platform: "linux", UploadPath: tmpDir})
+
+	if srv1.id != srv2.id {
+		t.Errorf("same config should produce same ID: %q != %q", srv1.id, srv2.id)
+	}
+	if srv1.id == srv3.id {
+		t.Errorf("different names should produce different IDs: %q == %q", srv1.id, srv3.id)
+	}
+}
+
+func TestGetInfo(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv, _ := New(Config{
+		Name:       "test-agent",
+		Platform:   "linux",
+		Version:    "1.2.3",
+		UploadPath: tmpDir,
+	})
+
+	info := srv.GetInfo()
+
+	if info.Name != "test-agent" {
+		t.Errorf("info.Name = %q, want %q", info.Name, "test-agent")
+	}
+	if info.Platform != "linux" {
+		t.Errorf("info.Platform = %q, want %q", info.Platform, "linux")
+	}
+	if info.Version != "1.2.3" {
+		t.Errorf("info.Version = %q, want %q", info.Version, "1.2.3")
+	}
+	if !info.AcceptConnections {
+		t.Error("info.AcceptConnections = false, want true (default)")
+	}
+	if len(info.Capabilities) == 0 {
+		t.Error("info.Capabilities is empty")
+	}
+	if len(info.SupportedImageFormats) == 0 {
+		t.Error("info.SupportedImageFormats is empty")
+	}
+}
+
+func TestGetInfo_AcceptConnectionsCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv, _ := New(Config{
+		Name:              "test-agent",
+		Platform:          "linux",
+		UploadPath:        tmpDir,
+		AcceptConnections: func() bool { return false },
+	})
+
+	info := srv.GetInfo()
+	if info.AcceptConnections {
+		t.Error("info.AcceptConnections = true, want false")
+	}
+}
+
+func TestGetUploadPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv, _ := New(Config{
+		Name:       "test",
+		Platform:   "linux",
+		UploadPath: tmpDir,
+	})
+
+	got := srv.GetUploadPath("MyGame", "")
+	want := filepath.Join(tmpDir, "MyGame")
+	if got != want {
+		t.Errorf("GetUploadPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGetUploadPath_WithCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	customPath := filepath.Join(tmpDir, "custom")
+
+	srv, _ := New(Config{
+		Name:           "test",
+		Platform:       "linux",
+		UploadPath:     tmpDir,
+		GetInstallPath: func() string { return customPath },
+	})
+
+	got := srv.GetUploadPath("MyGame", "")
+	want := filepath.Join(customPath, "MyGame")
+	if got != want {
+		t.Errorf("GetUploadPath() = %q, want %q", got, want)
+	}
+}
+
+func TestCreateAndGetUpload(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv, _ := New(Config{
+		Name:       "test",
+		Platform:   "linux",
+		UploadPath: tmpDir,
+	})
+
+	cfg := protocol.UploadConfig{
+		GameName: "Test Game",
+	}
+	files := []transfer.FileEntry{
+		{RelativePath: "game.exe", Size: 1024},
+	}
+
+	session := srv.CreateUpload(cfg, 1024, files)
+	if session == nil {
+		t.Fatal("CreateUpload() returned nil")
+	}
+	if session.ID == "" {
+		t.Error("session.ID is empty")
+	}
+
+	// Get the upload
+	got, ok := srv.GetUpload(session.ID)
+	if !ok {
+		t.Fatal("GetUpload() not found")
+	}
+	if got.ID != session.ID {
+		t.Errorf("GetUpload().ID = %q, want %q", got.ID, session.ID)
+	}
+}
+
+func TestGetUpload_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv, _ := New(Config{
+		Name:       "test",
+		Platform:   "linux",
+		UploadPath: tmpDir,
+	})
+
+	_, ok := srv.GetUpload("nonexistent")
+	if ok {
+		t.Error("GetUpload() found a nonexistent upload")
+	}
+}
+
+func TestDeleteUpload(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv, _ := New(Config{
+		Name:       "test",
+		Platform:   "linux",
+		UploadPath: tmpDir,
+	})
+
+	session := srv.CreateUpload(protocol.UploadConfig{GameName: "Game"}, 100, nil)
+
+	srv.DeleteUpload(session.ID)
+
+	_, ok := srv.GetUpload(session.ID)
+	if ok {
+		t.Error("GetUpload() still found upload after DeleteUpload()")
+	}
+}
+
+func TestNotifyShortcutChange(t *testing.T) {
+	tmpDir := t.TempDir()
+	called := false
+
+	srv, _ := New(Config{
+		Name:             "test",
+		Platform:         "linux",
+		UploadPath:       tmpDir,
+		OnShortcutChange: func() { called = true },
+	})
+
+	srv.NotifyShortcutChange()
+
+	if !called {
+		t.Error("OnShortcutChange callback was not called")
+	}
+}
+
+func TestNotifyShortcutChange_NilCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv, _ := New(Config{
+		Name:       "test",
+		Platform:   "linux",
+		UploadPath: tmpDir,
+	})
+
+	// Should not panic
+	srv.NotifyShortcutChange()
+}
+
+func TestNotifyOperation(t *testing.T) {
+	tmpDir := t.TempDir()
+	var received OperationEvent
+
+	srv, _ := New(Config{
+		Name:       "test",
+		Platform:   "linux",
+		UploadPath: tmpDir,
+		OnOperation: func(event OperationEvent) {
+			received = event
+		},
+	})
+
+	srv.NotifyOperation("install", "progress", "Test Game", 50.0, "downloading")
+
+	if received.Type != "install" {
+		t.Errorf("event.Type = %q, want %q", received.Type, "install")
+	}
+	if received.Status != "progress" {
+		t.Errorf("event.Status = %q, want %q", received.Status, "progress")
+	}
+	if received.GameName != "Test Game" {
+		t.Errorf("event.GameName = %q, want %q", received.GameName, "Test Game")
+	}
+	if received.Progress != 50.0 {
+		t.Errorf("event.Progress = %f, want %f", received.Progress, 50.0)
+	}
+}
+
+func TestNotifyOperation_NilCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv, _ := New(Config{
+		Name:       "test",
+		Platform:   "linux",
+		UploadPath: tmpDir,
+	})
+
+	// Should not panic
+	srv.NotifyOperation("install", "start", "Game", 0, "")
+}

--- a/apps/agents/desktop/shortcuts/manager_test.go
+++ b/apps/agents/desktop/shortcuts/manager_test.go
@@ -1,0 +1,481 @@
+package shortcuts
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/lobinuxsoft/capydeploy/pkg/protocol"
+	"github.com/lobinuxsoft/capydeploy/pkg/steam"
+	"github.com/shadowblip/steam-shortcut-manager/pkg/shortcut"
+)
+
+// newTestShortcuts creates a Shortcuts struct with named shortcuts for testing.
+func newTestShortcuts(entries map[string]string) *shortcut.Shortcuts {
+	sc := shortcut.NewShortcuts()
+	for key, name := range entries {
+		sc.Shortcuts[key] = shortcut.Shortcut{AppName: name}
+	}
+	return sc
+}
+
+// --- Pure function tests ---
+
+func TestTagsToSlice(t *testing.T) {
+	tests := []struct {
+		name string
+		tags map[string]interface{}
+		want int // expected length (order is non-deterministic from map)
+	}{
+		{"nil map", nil, 0},
+		{"empty map", map[string]interface{}{}, 0},
+		{"single tag", map[string]interface{}{"0": "RPG"}, 1},
+		{"multiple tags", map[string]interface{}{"0": "RPG", "1": "Action"}, 2},
+		{"non-string values ignored", map[string]interface{}{"0": "RPG", "1": 42}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tagsToSlice(tt.tags)
+			if tt.tags == nil {
+				if got != nil {
+					t.Errorf("tagsToSlice(nil) = %v, want nil", got)
+				}
+				return
+			}
+			if len(got) != tt.want {
+				t.Errorf("tagsToSlice() len = %d, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestSliceToTags(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []string
+		want int
+	}{
+		{"nil slice", nil, 0},
+		{"empty slice", []string{}, 0},
+		{"single tag", []string{"RPG"}, 1},
+		{"multiple tags", []string{"RPG", "Action", "Indie"}, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sliceToTags(tt.tags)
+			if len(tt.tags) == 0 {
+				if got != nil {
+					t.Errorf("sliceToTags(%v) = %v, want nil", tt.tags, got)
+				}
+				return
+			}
+			if len(got) != tt.want {
+				t.Errorf("sliceToTags() len = %d, want %d", len(got), tt.want)
+			}
+			// Verify values are accessible
+			for i, tag := range tt.tags {
+				key := string(rune('0') + rune(i))
+				if i >= 10 {
+					// sliceToTags uses strconv.Itoa, not rune math
+					break
+				}
+				if got[key] != tag {
+					t.Errorf("sliceToTags()[%q] = %v, want %q", key, got[key], tag)
+				}
+			}
+		})
+	}
+}
+
+func TestSliceToTagsRoundTrip(t *testing.T) {
+	input := []string{"RPG", "Action", "Indie"}
+	tags := sliceToTags(input)
+	result := tagsToSlice(tags)
+
+	if len(result) != len(input) {
+		t.Fatalf("round trip: got %d tags, want %d", len(result), len(input))
+	}
+
+	// Since map iteration order is non-deterministic, check all input values are present
+	have := make(map[string]bool)
+	for _, v := range result {
+		have[v] = true
+	}
+	for _, v := range input {
+		if !have[v] {
+			t.Errorf("round trip: missing tag %q", v)
+		}
+	}
+}
+
+func TestExpandPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"absolute path unchanged", "/usr/bin/game", "/usr/bin/game"},
+		{"relative path unchanged", "games/test", "games/test"},
+		{"tilde expands", "~/Games/test", filepath.Join(home, "Games/test")},
+		{"tilde alone not expanded", "~", "~"},
+		{"tilde in middle not expanded", "/home/~user/games", "/home/~user/games"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := expandPath(tt.path); got != tt.want {
+				t.Errorf("expandPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuotePath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"simple path", "/usr/bin/game", "/usr/bin/game"},
+		{"already quoted", `"/usr/bin/game"`, "/usr/bin/game"},
+	}
+
+	if runtime.GOOS == "windows" {
+		// On Windows, quotePath adds quotes
+		tests = []struct {
+			name string
+			path string
+			want string
+		}{
+			{"simple path", `C:\Games\test`, `"C:\Games\test"`},
+			{"already quoted", `"C:\Games\test"`, `"C:\Games\test"`},
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := quotePath(tt.path); got != tt.want {
+				t.Errorf("quotePath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnquotePath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"unquoted path", "/usr/bin/game", "/usr/bin/game"},
+		{"quoted path", `"/usr/bin/game"`, "/usr/bin/game"},
+		{"single quote not removed", `'/usr/bin/game'`, `'/usr/bin/game'`},
+		{"empty string", "", ""},
+		{"only quotes", `""`, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := unquotePath(tt.path); got != tt.want {
+				t.Errorf("unquotePath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSubPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		parent string
+		child  string
+		want   bool
+	}{
+		{"child inside parent", "/home/user", "/home/user/games/test", true},
+		{"child is parent", "/home/user", "/home/user", false},
+		{"child outside parent", "/home/user", "/etc/config", false},
+		{"sibling directory", "/home/user", "/home/user2/games", false},
+		{"root as parent", "/", "/home/user", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSubPath(tt.parent, tt.child); got != tt.want {
+				t.Errorf("isSubPath(%q, %q) = %v, want %v", tt.parent, tt.child, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReindexShortcuts(t *testing.T) {
+	// Create a shortcut collection with non-sequential keys
+	sc := newTestShortcuts(map[string]string{
+		"5":  "GameA",
+		"10": "GameB",
+		"2":  "GameC",
+	})
+
+	result := reindexShortcuts(sc)
+
+	if len(result.Shortcuts) != 3 {
+		t.Fatalf("reindexShortcuts() returned %d shortcuts, want 3", len(result.Shortcuts))
+	}
+
+	// Keys should be "0", "1", "2"
+	for i := 0; i < 3; i++ {
+		key := string(rune('0') + rune(i))
+		if _, ok := result.Shortcuts[key]; !ok {
+			t.Errorf("reindexShortcuts(): missing key %q", key)
+		}
+	}
+}
+
+func TestDeleteGameDirectory_Safety(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"empty path is no-op", "", false},
+		{"root path rejected", "/", true},
+		{"home dir rejected", home, true},
+		{"top-level home subdir rejected", filepath.Join(home, "Games"), true},
+		{"system path rejected", "/etc", true},
+		{"nonexistent deep path is no-op", filepath.Join(home, "Games", "nonexistent_test_dir_12345"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := deleteGameDirectory(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("deleteGameDirectory(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeleteGameDirectory_ActualDelete(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
+	}
+
+	// Create a temp dir inside home at 2+ levels deep
+	tmpBase := filepath.Join(home, ".capydeploy-test")
+	gameDir := filepath.Join(tmpBase, "test-game")
+	if err := os.MkdirAll(gameDir, 0755); err != nil {
+		t.Fatalf("failed to create test dir: %v", err)
+	}
+	defer os.RemoveAll(tmpBase)
+
+	// Create a file inside
+	testFile := filepath.Join(gameDir, "game.exe")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	if err := deleteGameDirectory(gameDir); err != nil {
+		t.Errorf("deleteGameDirectory() error = %v", err)
+	}
+
+	if _, err := os.Stat(gameDir); !os.IsNotExist(err) {
+		t.Errorf("deleteGameDirectory() did not remove directory")
+	}
+}
+
+// --- Manager CRUD tests with VDF library ---
+
+func TestManager_ListEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	paths := steam.NewPathsWithBase(tmpDir)
+	mgr := NewManagerWithPaths(paths)
+
+	// No shortcuts.vdf exists yet
+	list, err := mgr.List("12345")
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("List() returned %d shortcuts, want 0", len(list))
+	}
+}
+
+func TestManager_CreateAndList(t *testing.T) {
+	tmpDir := t.TempDir()
+	paths := steam.NewPathsWithBase(tmpDir)
+	mgr := NewManagerWithPaths(paths)
+
+	userID := "12345"
+
+	// Ensure config dir exists for the user
+	configDir := paths.ConfigDir(userID)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	cfg := protocol.ShortcutConfig{
+		Name:          "Test Game",
+		Exe:           "/usr/bin/test-game",
+		StartDir:      "/usr/bin",
+		LaunchOptions: "--fullscreen",
+		Tags:          []string{"RPG", "Action"},
+	}
+
+	appID, err := mgr.Create(userID, cfg)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if appID == 0 {
+		t.Error("Create() returned appID 0")
+	}
+
+	// List should return the shortcut
+	list, err := mgr.List(userID)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("List() returned %d shortcuts, want 1", len(list))
+	}
+	if list[0].Name != "Test Game" {
+		t.Errorf("List()[0].Name = %q, want %q", list[0].Name, "Test Game")
+	}
+	if list[0].AppID != appID {
+		t.Errorf("List()[0].AppID = %d, want %d", list[0].AppID, appID)
+	}
+}
+
+func TestManager_CreateDuplicate(t *testing.T) {
+	tmpDir := t.TempDir()
+	paths := steam.NewPathsWithBase(tmpDir)
+	mgr := NewManagerWithPaths(paths)
+
+	userID := "12345"
+	if err := os.MkdirAll(paths.ConfigDir(userID), 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	cfg := protocol.ShortcutConfig{
+		Name: "Test Game",
+		Exe:  "/usr/bin/test-game",
+	}
+
+	if _, err := mgr.Create(userID, cfg); err != nil {
+		t.Fatalf("first Create() error = %v", err)
+	}
+
+	// Second create with same exe+name should fail
+	_, err := mgr.Create(userID, cfg)
+	if err == nil {
+		t.Error("second Create() should return error for duplicate shortcut")
+	}
+}
+
+func TestManager_Delete(t *testing.T) {
+	tmpDir := t.TempDir()
+	paths := steam.NewPathsWithBase(tmpDir)
+	mgr := NewManagerWithPaths(paths)
+
+	userID := "12345"
+	if err := os.MkdirAll(paths.ConfigDir(userID), 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	cfg := protocol.ShortcutConfig{
+		Name:     "Test Game",
+		Exe:      "/usr/bin/test-game",
+		StartDir: "/usr/bin",
+	}
+
+	appID, err := mgr.Create(userID, cfg)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Delete without cleanup to avoid filesystem side effects
+	if err := mgr.DeleteWithCleanup(userID, appID, "", false); err != nil {
+		t.Fatalf("DeleteWithCleanup() error = %v", err)
+	}
+
+	// List should be empty
+	list, err := mgr.List(userID)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("List() returned %d shortcuts after delete, want 0", len(list))
+	}
+}
+
+func TestManager_DeleteByName(t *testing.T) {
+	tmpDir := t.TempDir()
+	paths := steam.NewPathsWithBase(tmpDir)
+	mgr := NewManagerWithPaths(paths)
+
+	userID := "12345"
+	if err := os.MkdirAll(paths.ConfigDir(userID), 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	cfg := protocol.ShortcutConfig{
+		Name:     "My Game",
+		Exe:      "/usr/bin/my-game",
+		StartDir: "/usr/bin",
+	}
+
+	if _, err := mgr.Create(userID, cfg); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Delete by name (appID=0)
+	if err := mgr.DeleteWithCleanup(userID, 0, "My Game", false); err != nil {
+		t.Fatalf("DeleteWithCleanup() by name error = %v", err)
+	}
+
+	list, err := mgr.List(userID)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("List() returned %d shortcuts after delete by name, want 0", len(list))
+	}
+}
+
+func TestManager_DeleteNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	paths := steam.NewPathsWithBase(tmpDir)
+	mgr := NewManagerWithPaths(paths)
+
+	userID := "12345"
+	if err := os.MkdirAll(paths.ConfigDir(userID), 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	// Create one shortcut so shortcuts.vdf exists
+	cfg := protocol.ShortcutConfig{
+		Name:     "Existing Game",
+		Exe:      "/usr/bin/existing",
+		StartDir: "/usr/bin",
+	}
+	if _, err := mgr.Create(userID, cfg); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Try to delete a non-existent shortcut
+	err := mgr.DeleteWithCleanup(userID, 99999, "", false)
+	if err == nil {
+		t.Error("DeleteWithCleanup() should return error for non-existent shortcut")
+	}
+}

--- a/apps/hub/auth/auth_test.go
+++ b/apps/hub/auth/auth_test.go
@@ -1,0 +1,129 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewTokenStore(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	store, err := NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+
+	if store.GetHubID() == "" {
+		t.Error("GetHubID() returned empty string")
+	}
+}
+
+func TestGetHubID_Stable(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	store1, _ := NewTokenStore()
+	id1 := store1.GetHubID()
+
+	// Reload
+	store2, _ := NewTokenStore()
+	id2 := store2.GetHubID()
+
+	if id1 != id2 {
+		t.Errorf("Hub IDs should persist: %q != %q", id1, id2)
+	}
+}
+
+func TestSaveToken(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	store, _ := NewTokenStore()
+
+	if err := store.SaveToken("agent-1", "my-secret-token"); err != nil {
+		t.Fatalf("SaveToken() error = %v", err)
+	}
+
+	if got := store.GetToken("agent-1"); got != "my-secret-token" {
+		t.Errorf("GetToken() = %q, want %q", got, "my-secret-token")
+	}
+}
+
+func TestGetToken_NotFound(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	store, _ := NewTokenStore()
+
+	if got := store.GetToken("nonexistent"); got != "" {
+		t.Errorf("GetToken() for unknown agent = %q, want empty", got)
+	}
+}
+
+func TestRemoveToken(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	store, _ := NewTokenStore()
+	store.SaveToken("agent-1", "token-1")
+
+	if err := store.RemoveToken("agent-1"); err != nil {
+		t.Fatalf("RemoveToken() error = %v", err)
+	}
+
+	if got := store.GetToken("agent-1"); got != "" {
+		t.Errorf("GetToken() after remove = %q, want empty", got)
+	}
+}
+
+func TestHasToken(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	store, _ := NewTokenStore()
+
+	if store.HasToken("agent-1") {
+		t.Error("HasToken() = true before saving")
+	}
+
+	store.SaveToken("agent-1", "token")
+
+	if !store.HasToken("agent-1") {
+		t.Error("HasToken() = false after saving")
+	}
+}
+
+func TestPersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	store1, _ := NewTokenStore()
+	store1.SaveToken("agent-1", "token-persist")
+	store1.SaveToken("agent-2", "token-persist-2")
+
+	// Reload from disk
+	store2, _ := NewTokenStore()
+
+	if got := store2.GetToken("agent-1"); got != "token-persist" {
+		t.Errorf("persisted token = %q, want %q", got, "token-persist")
+	}
+	if got := store2.GetToken("agent-2"); got != "token-persist-2" {
+		t.Errorf("persisted token 2 = %q, want %q", got, "token-persist-2")
+	}
+}
+
+func TestSave_FilePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	store, _ := NewTokenStore()
+	store.SaveToken("agent-1", "token")
+
+	tokensPath := filepath.Join(tmpDir, "capydeploy-hub", "tokens.json")
+	info, err := os.Stat(tokensPath)
+	if err != nil {
+		t.Fatalf("tokens file not found: %v", err)
+	}
+
+	perm := info.Mode().Perm()
+	if perm != 0600 {
+		t.Errorf("tokens file permissions = %o, want 0600", perm)
+	}
+}

--- a/apps/hub/config/config_test.go
+++ b/apps/hub/config/config_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestNewManager(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if mgr.GetID() == "" {
+		t.Error("GetID() returned empty string")
+	}
+	if mgr.GetName() == "" {
+		t.Error("GetName() returned empty string")
+	}
+	if mgr.GetPlatform() == "" {
+		t.Error("GetPlatform() returned empty string")
+	}
+}
+
+func TestGetID_Stable(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	mgr1, _ := NewManager()
+	id1 := mgr1.GetID()
+
+	// Create another manager from the same config dir
+	mgr2, _ := NewManager()
+	id2 := mgr2.GetID()
+
+	if id1 != id2 {
+		t.Errorf("IDs should be stable: %q != %q", id1, id2)
+	}
+}
+
+func TestGetID_Length(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, _ := NewManager()
+	id := mgr.GetID()
+
+	// ID is first 8 hex chars of SHA256
+	if len(id) != 8 {
+		t.Errorf("GetID() length = %d, want 8", len(id))
+	}
+}
+
+func TestSetName(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, _ := NewManager()
+
+	if err := mgr.SetName("my-hub"); err != nil {
+		t.Fatalf("SetName() error = %v", err)
+	}
+
+	if got := mgr.GetName(); got != "my-hub" {
+		t.Errorf("GetName() = %q, want %q", got, "my-hub")
+	}
+}
+
+func TestGetPlatform(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, _ := NewManager()
+
+	if got := mgr.GetPlatform(); got != runtime.GOOS {
+		t.Errorf("GetPlatform() = %q, want %q", got, runtime.GOOS)
+	}
+}
+
+func TestSaveAndReload(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	mgr1, _ := NewManager()
+	originalID := mgr1.GetID()
+	mgr1.SetName("persistent-hub")
+
+	// Create new manager that reloads from disk
+	mgr2, _ := NewManager()
+
+	if got := mgr2.GetName(); got != "persistent-hub" {
+		t.Errorf("reloaded name = %q, want %q", got, "persistent-hub")
+	}
+	if got := mgr2.GetID(); got != originalID {
+		t.Errorf("reloaded ID = %q, want %q (should persist)", got, originalID)
+	}
+}
+
+func TestGetConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	mgr, _ := NewManager()
+	mgr.SetName("config-test")
+
+	cfg := mgr.GetConfig()
+	if cfg.Name != "config-test" {
+		t.Errorf("GetConfig().Name = %q, want %q", cfg.Name, "config-test")
+	}
+	if cfg.ID == "" {
+		t.Error("GetConfig().ID is empty")
+	}
+	if cfg.Platform == "" {
+		t.Error("GetConfig().Platform is empty")
+	}
+}
+
+func TestSave_ValidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	mgr, _ := NewManager()
+	mgr.SetName("json-hub")
+
+	configPath := filepath.Join(tmpDir, "capydeploy-hub", "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("config is not valid JSON: %v", err)
+	}
+
+	if cfg.Name != "json-hub" {
+		t.Errorf("saved name = %q, want %q", cfg.Name, "json-hub")
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,311 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestLoad_Default(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	// Default config should have image cache enabled
+	if !cfg.ImageCacheEnabled {
+		t.Error("default ImageCacheEnabled = false, want true")
+	}
+	if len(cfg.GameSetups) != 0 {
+		t.Errorf("default GameSetups len = %d, want 0", len(cfg.GameSetups))
+	}
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	original := &AppConfig{
+		GameSetups: []GameSetup{
+			{ID: "game-1", Name: "Test Game", LocalPath: "/games/test"},
+		},
+		SteamGridDBAPIKey: "test-key",
+		ImageCacheEnabled: true,
+	}
+
+	if err := Save(original); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(loaded.GameSetups) != 1 {
+		t.Fatalf("loaded GameSetups len = %d, want 1", len(loaded.GameSetups))
+	}
+	if loaded.GameSetups[0].Name != "Test Game" {
+		t.Errorf("loaded game name = %q, want %q", loaded.GameSetups[0].Name, "Test Game")
+	}
+	if loaded.SteamGridDBAPIKey != "test-key" {
+		t.Errorf("loaded API key = %q, want %q", loaded.SteamGridDBAPIKey, "test-key")
+	}
+}
+
+func TestAddGameSetup(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	setup := GameSetup{
+		Name:      "My Game",
+		LocalPath: "/home/user/games/mygame",
+		Executable: "game.exe",
+	}
+
+	if err := AddGameSetup(setup); err != nil {
+		t.Fatalf("AddGameSetup() error = %v", err)
+	}
+
+	setups, err := GetGameSetups()
+	if err != nil {
+		t.Fatalf("GetGameSetups() error = %v", err)
+	}
+
+	if len(setups) != 1 {
+		t.Fatalf("GetGameSetups() len = %d, want 1", len(setups))
+	}
+	if setups[0].Name != "My Game" {
+		t.Errorf("setup name = %q, want %q", setups[0].Name, "My Game")
+	}
+	// ID should be auto-generated
+	if setups[0].ID == "" {
+		t.Error("setup ID should be auto-generated")
+	}
+}
+
+func TestAddGameSetup_WithID(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	setup := GameSetup{
+		ID:   "custom-id",
+		Name: "Custom Game",
+	}
+
+	if err := AddGameSetup(setup); err != nil {
+		t.Fatalf("AddGameSetup() error = %v", err)
+	}
+
+	setups, _ := GetGameSetups()
+	if setups[0].ID != "custom-id" {
+		t.Errorf("setup ID = %q, want %q", setups[0].ID, "custom-id")
+	}
+}
+
+func TestAddGameSetup_UpdateExisting(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	AddGameSetup(GameSetup{ID: "game-1", Name: "Old Name"})
+
+	// Add again with same ID should update
+	AddGameSetup(GameSetup{ID: "game-1", Name: "New Name"})
+
+	setups, _ := GetGameSetups()
+	if len(setups) != 1 {
+		t.Fatalf("expected 1 setup after update, got %d", len(setups))
+	}
+	if setups[0].Name != "New Name" {
+		t.Errorf("updated name = %q, want %q", setups[0].Name, "New Name")
+	}
+}
+
+func TestUpdateGameSetup(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	AddGameSetup(GameSetup{ID: "game-1", Name: "Original"})
+
+	updated := GameSetup{
+		Name:       "Updated Game",
+		Executable: "new.exe",
+	}
+
+	if err := UpdateGameSetup("game-1", updated); err != nil {
+		t.Fatalf("UpdateGameSetup() error = %v", err)
+	}
+
+	setups, _ := GetGameSetups()
+	if setups[0].Name != "Updated Game" {
+		t.Errorf("updated name = %q, want %q", setups[0].Name, "Updated Game")
+	}
+	if setups[0].ID != "game-1" {
+		t.Errorf("ID should be preserved: %q", setups[0].ID)
+	}
+}
+
+func TestUpdateGameSetup_NotFound(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	err := UpdateGameSetup("nonexistent", GameSetup{Name: "New"})
+	if err == nil {
+		t.Error("UpdateGameSetup() should return error for nonexistent ID")
+	}
+}
+
+func TestRemoveGameSetup(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	AddGameSetup(GameSetup{ID: "game-1", Name: "Game 1"})
+	AddGameSetup(GameSetup{ID: "game-2", Name: "Game 2"})
+
+	if err := RemoveGameSetup("game-1"); err != nil {
+		t.Fatalf("RemoveGameSetup() error = %v", err)
+	}
+
+	setups, _ := GetGameSetups()
+	if len(setups) != 1 {
+		t.Fatalf("expected 1 setup after remove, got %d", len(setups))
+	}
+	if setups[0].ID != "game-2" {
+		t.Errorf("remaining setup ID = %q, want %q", setups[0].ID, "game-2")
+	}
+}
+
+func TestRemoveGameSetup_NotFound(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// Removing non-existent setup should not error
+	if err := RemoveGameSetup("nonexistent"); err != nil {
+		t.Errorf("RemoveGameSetup() error = %v, want nil", err)
+	}
+}
+
+func TestGetSetSteamGridDBAPIKey(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// Default should be empty
+	key, err := GetSteamGridDBAPIKey()
+	if err != nil {
+		t.Fatalf("GetSteamGridDBAPIKey() error = %v", err)
+	}
+	if key != "" {
+		t.Errorf("default API key = %q, want empty", key)
+	}
+
+	// Set
+	if err := SetSteamGridDBAPIKey("my-api-key-123"); err != nil {
+		t.Fatalf("SetSteamGridDBAPIKey() error = %v", err)
+	}
+
+	// Get
+	key, err = GetSteamGridDBAPIKey()
+	if err != nil {
+		t.Fatalf("GetSteamGridDBAPIKey() error = %v", err)
+	}
+	if key != "my-api-key-123" {
+		t.Errorf("API key = %q, want %q", key, "my-api-key-123")
+	}
+}
+
+func TestGetSetImageCacheEnabled(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// Default should be true
+	enabled, err := GetImageCacheEnabled()
+	if err != nil {
+		t.Fatalf("GetImageCacheEnabled() error = %v", err)
+	}
+	if !enabled {
+		t.Error("default ImageCacheEnabled = false, want true")
+	}
+
+	// Disable
+	if err := SetImageCacheEnabled(false); err != nil {
+		t.Fatalf("SetImageCacheEnabled() error = %v", err)
+	}
+
+	enabled, err = GetImageCacheEnabled()
+	if err != nil {
+		t.Fatalf("GetImageCacheEnabled() error = %v", err)
+	}
+	if enabled {
+		t.Error("ImageCacheEnabled = true after setting false")
+	}
+}
+
+func TestSave_FilePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	Save(&AppConfig{ImageCacheEnabled: true})
+
+	configPath, _ := GetConfigPath()
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("config file not found: %v", err)
+	}
+
+	perm := info.Mode().Perm()
+	if perm != 0600 {
+		t.Errorf("config file permissions = %o, want 0600", perm)
+	}
+}
+
+func TestSave_ValidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	Save(&AppConfig{
+		GameSetups:        []GameSetup{{ID: "g1", Name: "Game"}},
+		SteamGridDBAPIKey: "key",
+		ImageCacheEnabled: true,
+	})
+
+	configPath, _ := GetConfigPath()
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	var cfg AppConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("config is not valid JSON: %v", err)
+	}
+}
+
+func TestGameSetup_AllFields(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	setup := GameSetup{
+		ID:             "test-full",
+		Name:           "Full Game",
+		LocalPath:      "/home/user/games/full",
+		Executable:     "game.sh",
+		LaunchOptions:  "--windowed",
+		Tags:           "rpg,action",
+		InstallPath:    "~/Games/Full",
+		GridDBGameID:   42,
+		GridPortrait:   "https://example.com/portrait.png",
+		GridLandscape:  "https://example.com/landscape.png",
+		HeroImage:      "https://example.com/hero.png",
+		LogoImage:      "https://example.com/logo.png",
+		IconImage:      "https://example.com/icon.png",
+	}
+
+	AddGameSetup(setup)
+
+	setups, _ := GetGameSetups()
+	if len(setups) != 1 {
+		t.Fatalf("expected 1 setup, got %d", len(setups))
+	}
+
+	got := setups[0]
+	if got.GridDBGameID != 42 {
+		t.Errorf("GridDBGameID = %d, want 42", got.GridDBGameID)
+	}
+	if got.Tags != "rpg,action" {
+		t.Errorf("Tags = %q, want %q", got.Tags, "rpg,action")
+	}
+	if got.HeroImage != "https://example.com/hero.png" {
+		t.Errorf("HeroImage = %q, want %q", got.HeroImage, "https://example.com/hero.png")
+	}
+}

--- a/pkg/steamgriddb/client_test.go
+++ b/pkg/steamgriddb/client_test.go
@@ -1,0 +1,458 @@
+package steamgriddb
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTestClient creates a Client pointing at the given test server URL.
+func newTestClient(serverURL string) *Client {
+	c := NewClient("test-api-key")
+	// Override the baseURL by injecting the test server URL into the client's transport.
+	// Since Client uses the default httpClient, we redirect by intercepting at transport level.
+	c.httpClient = http.Client{
+		Transport: &rewriteTransport{
+			base:    http.DefaultTransport,
+			baseURL: serverURL,
+		},
+	}
+	return c
+}
+
+// rewriteTransport rewrites requests to point at a test server.
+type rewriteTransport struct {
+	base    http.RoundTripper
+	baseURL string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace the scheme+host with the test server, keep the path+query
+	u, _ := url.Parse(t.baseURL)
+	req.URL.Scheme = u.Scheme
+	req.URL.Host = u.Host
+	return t.base.RoundTrip(req)
+}
+
+func TestSearch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth header
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			t.Error("missing Bearer token")
+		}
+
+		if !strings.Contains(r.URL.Path, "/search/autocomplete/") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		resp := searchResponse{
+			apiResponse: apiResponse{Success: true},
+			Data: []SearchResult{
+				{ID: 1, Name: "Test Game", Types: []string{"steam"}, Verified: true},
+				{ID: 2, Name: "Test Game 2", Types: []string{"origin"}},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL)
+	results, err := client.Search("Test Game")
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("Search() returned %d results, want 2", len(results))
+	}
+	if results[0].Name != "Test Game" {
+		t.Errorf("results[0].Name = %q, want %q", results[0].Name, "Test Game")
+	}
+}
+
+func TestGetGrids(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/grids/game/42") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		resp := gridResponse{
+			apiResponse: apiResponse{Success: true},
+			Data: []GridData{
+				{ID: 100, URL: "https://example.com/grid.png", Width: 920, Height: 430},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL)
+	grids, err := client.GetGrids(42, nil, 0)
+	if err != nil {
+		t.Fatalf("GetGrids() error = %v", err)
+	}
+
+	if len(grids) != 1 {
+		t.Fatalf("GetGrids() returned %d results, want 1", len(grids))
+	}
+	if grids[0].Width != 920 {
+		t.Errorf("grids[0].Width = %d, want 920", grids[0].Width)
+	}
+}
+
+func TestGetHeroes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/heroes/game/42") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		resp := imageResponse{
+			apiResponse: apiResponse{Success: true},
+			Data: []ImageData{
+				{ID: 200, URL: "https://example.com/hero.png", Width: 1920, Height: 620},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL)
+	heroes, err := client.GetHeroes(42, nil, 0)
+	if err != nil {
+		t.Fatalf("GetHeroes() error = %v", err)
+	}
+
+	if len(heroes) != 1 {
+		t.Fatalf("GetHeroes() returned %d results, want 1", len(heroes))
+	}
+}
+
+func TestGetLogos(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := imageResponse{
+			apiResponse: apiResponse{Success: true},
+			Data: []ImageData{
+				{ID: 300, URL: "https://example.com/logo.png"},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL)
+	logos, err := client.GetLogos(42, nil, 0)
+	if err != nil {
+		t.Fatalf("GetLogos() error = %v", err)
+	}
+
+	if len(logos) != 1 {
+		t.Fatalf("GetLogos() returned %d results, want 1", len(logos))
+	}
+}
+
+func TestGetIcons(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := imageResponse{
+			apiResponse: apiResponse{Success: true},
+			Data: []ImageData{
+				{ID: 400, URL: "https://example.com/icon.png"},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL)
+	icons, err := client.GetIcons(42, nil, 0)
+	if err != nil {
+		t.Fatalf("GetIcons() error = %v", err)
+	}
+
+	if len(icons) != 1 {
+		t.Fatalf("GetIcons() returned %d results, want 1", len(icons))
+	}
+}
+
+func TestSearch_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"success":false,"errors":["Unauthorized"]}`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL)
+	_, err := client.Search("test")
+	if err == nil {
+		t.Error("Search() should return error on 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error should mention status code: %v", err)
+	}
+}
+
+func TestBuildParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters *ImageFilters
+		page    int
+		want    map[string]string // expected param key→value pairs
+		notWant []string          // keys that should NOT be present
+	}{
+		{
+			name:    "nil filters, no page",
+			filters: nil,
+			page:    0,
+			want:    map[string]string{},
+		},
+		{
+			name:    "page only",
+			filters: nil,
+			page:    2,
+			want:    map[string]string{"page": "2"},
+		},
+		{
+			name: "style filter",
+			filters: &ImageFilters{
+				Style: "alternate",
+			},
+			page: 0,
+			want: map[string]string{"styles": "alternate", "nsfw": "false", "humor": "false"},
+		},
+		{
+			name: "all styles ignored",
+			filters: &ImageFilters{
+				Style: "All Styles",
+			},
+			page:    0,
+			notWant: []string{"styles"},
+		},
+		{
+			name: "static animation type",
+			filters: &ImageFilters{
+				ImageType: "static",
+			},
+			page: 0,
+			want: map[string]string{"types": "static"},
+		},
+		{
+			name: "animated frontend label",
+			filters: &ImageFilters{
+				ImageType: "Animated Only",
+			},
+			page: 0,
+			want: map[string]string{"types": "animated"},
+		},
+		{
+			name: "nsfw and humor enabled",
+			filters: &ImageFilters{
+				ShowNsfw:  true,
+				ShowHumor: true,
+			},
+			page: 0,
+			want: map[string]string{"nsfw": "any", "humor": "any"},
+		},
+		{
+			name: "mime type filter",
+			filters: &ImageFilters{
+				MimeType: "image/png",
+			},
+			page: 0,
+			want: map[string]string{"mimes": "image/png"},
+		},
+		{
+			name: "dimension filter",
+			filters: &ImageFilters{
+				Dimension: "600x900",
+			},
+			page: 0,
+			want: map[string]string{"dimensions": "600x900"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildParams(tt.filters, tt.page)
+
+			for key, wantVal := range tt.want {
+				if gotVal := got.Get(key); gotVal != wantVal {
+					t.Errorf("buildParams()[%q] = %q, want %q", key, gotVal, wantVal)
+				}
+			}
+
+			for _, key := range tt.notWant {
+				if got.Has(key) {
+					t.Errorf("buildParams() should not have key %q", key)
+				}
+			}
+		})
+	}
+}
+
+// --- Cache tests ---
+
+func TestSaveAndGetCachedImage(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	gameID := 12345
+	imageURL := "https://example.com/image.png"
+	testData := []byte("fake-png-data")
+
+	// Save
+	if err := SaveImageToCache(gameID, imageURL, testData, "image/png"); err != nil {
+		t.Fatalf("SaveImageToCache() error = %v", err)
+	}
+
+	// Get
+	data, contentType, err := GetCachedImage(gameID, imageURL)
+	if err != nil {
+		t.Fatalf("GetCachedImage() error = %v", err)
+	}
+	if string(data) != string(testData) {
+		t.Errorf("GetCachedImage() data mismatch")
+	}
+	if contentType != "image/png" {
+		t.Errorf("GetCachedImage() contentType = %q, want %q", contentType, "image/png")
+	}
+}
+
+func TestGetCachedImage_NotFound(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	_, _, err := GetCachedImage(99999, "https://example.com/nonexistent.png")
+	if err == nil {
+		t.Error("GetCachedImage() should return error for non-cached image")
+	}
+}
+
+func TestClearImageCache(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// Save some test data
+	if err := SaveImageToCache(1, "https://example.com/a.png", []byte("aaa"), "image/png"); err != nil {
+		t.Fatalf("SaveImageToCache() error = %v", err)
+	}
+	if err := SaveImageToCache(2, "https://example.com/b.jpg", []byte("bbb"), "image/jpeg"); err != nil {
+		t.Fatalf("SaveImageToCache() error = %v", err)
+	}
+
+	if err := ClearImageCache(); err != nil {
+		t.Fatalf("ClearImageCache() error = %v", err)
+	}
+
+	// Cache should be empty
+	size, err := GetCacheSize()
+	if err != nil {
+		t.Fatalf("GetCacheSize() error = %v", err)
+	}
+	if size != 0 {
+		t.Errorf("GetCacheSize() after clear = %d, want 0", size)
+	}
+}
+
+func TestGetCacheSize(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// Empty cache should be 0
+	size, err := GetCacheSize()
+	if err != nil {
+		t.Fatalf("GetCacheSize() error = %v", err)
+	}
+	if size != 0 {
+		t.Errorf("GetCacheSize() empty cache = %d, want 0", size)
+	}
+
+	// Save some data
+	testData := []byte("some-image-data-here")
+	if err := SaveImageToCache(1, "https://example.com/test.png", testData, "image/png"); err != nil {
+		t.Fatalf("SaveImageToCache() error = %v", err)
+	}
+
+	size, err = GetCacheSize()
+	if err != nil {
+		t.Fatalf("GetCacheSize() error = %v", err)
+	}
+	if size != int64(len(testData)) {
+		t.Errorf("GetCacheSize() = %d, want %d", size, len(testData))
+	}
+}
+
+func TestSaveImageToCache_ContentTypes(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	tests := []struct {
+		contentType string
+		expectedExt string
+	}{
+		{"image/png", ".png"},
+		{"image/jpeg", ".jpg"},
+		{"image/webp", ".webp"},
+		{"image/gif", ".gif"},
+		{"image/unknown", ".jpg"}, // default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.contentType, func(t *testing.T) {
+			url := "https://example.com/" + tt.contentType
+			if err := SaveImageToCache(1, url, []byte("test"), tt.contentType); err != nil {
+				t.Fatalf("SaveImageToCache() error = %v", err)
+			}
+
+			// Verify file was saved with correct extension
+			path, err := GetCachedImagePath(1, url)
+			if err != nil {
+				t.Fatalf("GetCachedImagePath() error = %v", err)
+			}
+			ext := filepath.Ext(path)
+			if ext != tt.expectedExt {
+				t.Errorf("saved file ext = %q, want %q", ext, tt.expectedExt)
+			}
+		})
+	}
+}
+
+func TestHashURL(t *testing.T) {
+	// Same URL should produce same hash
+	h1 := hashURL("https://example.com/image.png")
+	h2 := hashURL("https://example.com/image.png")
+	if h1 != h2 {
+		t.Errorf("hashURL() not deterministic: %q != %q", h1, h2)
+	}
+
+	// Different URLs should produce different hashes
+	h3 := hashURL("https://example.com/other.png")
+	if h1 == h3 {
+		t.Errorf("hashURL() collision: %q == %q", h1, h3)
+	}
+
+	// Hash should be 32 hex chars (16 bytes)
+	if len(h1) != 32 {
+		t.Errorf("hashURL() length = %d, want 32", len(h1))
+	}
+}
+
+func TestGetGameCacheDir(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	dir, err := GetGameCacheDir(42)
+	if err != nil {
+		t.Fatalf("GetGameCacheDir() error = %v", err)
+	}
+
+	if !strings.Contains(dir, "game_42") {
+		t.Errorf("GetGameCacheDir() = %q, should contain 'game_42'", dir)
+	}
+
+	// Directory should exist
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("GetGameCacheDir() created dir does not exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("GetGameCacheDir() did not create a directory")
+	}
+}

--- a/pkg/steamgriddb/thumbnail_test.go
+++ b/pkg/steamgriddb/thumbnail_test.go
@@ -1,0 +1,265 @@
+package steamgriddb
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// createTestPNG creates a minimal valid PNG image in memory.
+func createTestPNG(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	png.Encode(&buf, img)
+	return buf.Bytes()
+}
+
+// createTestJPEG creates a minimal valid JPEG image in memory.
+func createTestJPEG(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	var buf bytes.Buffer
+	jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80})
+	return buf.Bytes()
+}
+
+// createTestGIF creates a minimal valid GIF with 2 frames.
+func createTestGIF(width, height int) []byte {
+	palette := color.Palette{color.Black, color.White, color.RGBA{R: 255, A: 255}}
+
+	g := &gif.GIF{}
+	for i := 0; i < 2; i++ {
+		frame := image.NewPaletted(image.Rect(0, 0, width, height), palette)
+		for y := 0; y < height; y++ {
+			for x := 0; x < width; x++ {
+				frame.SetColorIndex(x, y, uint8(i%len(palette)))
+			}
+		}
+		g.Image = append(g.Image, frame)
+		g.Delay = append(g.Delay, 10)
+	}
+
+	var buf bytes.Buffer
+	gif.EncodeAll(&buf, g)
+	return buf.Bytes()
+}
+
+func TestResizeImage_Downscale(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 800, 600))
+
+	resized := resizeImage(img, 200, 0)
+
+	bounds := resized.Bounds()
+	if bounds.Dx() != 200 {
+		t.Errorf("resized width = %d, want 200", bounds.Dx())
+	}
+	// Proportional: 600 * 200 / 800 = 150
+	if bounds.Dy() != 150 {
+		t.Errorf("resized height = %d, want 150", bounds.Dy())
+	}
+}
+
+func TestResizeImage_NoResize(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 100, 100))
+
+	resized := resizeImage(img, 200, 0)
+
+	// Image is smaller than max, should not resize
+	if resized != img {
+		t.Error("resizeImage() should return original when no resize needed")
+	}
+}
+
+func TestResizeImage_MaxHeight(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 400, 800))
+
+	resized := resizeImage(img, 200, 100)
+
+	bounds := resized.Bounds()
+	if bounds.Dy() > 100 {
+		t.Errorf("resized height = %d, want <= 100", bounds.Dy())
+	}
+}
+
+func TestResizeImage_ZeroMax(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 300, 200))
+
+	resized := resizeImage(img, 0, 0)
+
+	// No constraints, should return original
+	if resized != img {
+		t.Error("resizeImage(0,0) should return original")
+	}
+}
+
+func TestDecodeFirstFrame_PNG(t *testing.T) {
+	data := createTestPNG(100, 50)
+
+	img, err := decodeFirstFrame(data, "image/png", "test.png")
+	if err != nil {
+		t.Fatalf("decodeFirstFrame(PNG) error = %v", err)
+	}
+
+	bounds := img.Bounds()
+	if bounds.Dx() != 100 || bounds.Dy() != 50 {
+		t.Errorf("decoded PNG size = %dx%d, want 100x50", bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestDecodeFirstFrame_JPEG(t *testing.T) {
+	data := createTestJPEG(120, 80)
+
+	img, err := decodeFirstFrame(data, "image/jpeg", "test.jpg")
+	if err != nil {
+		t.Fatalf("decodeFirstFrame(JPEG) error = %v", err)
+	}
+
+	bounds := img.Bounds()
+	if bounds.Dx() != 120 || bounds.Dy() != 80 {
+		t.Errorf("decoded JPEG size = %dx%d, want 120x80", bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestDecodeFirstFrame_GIF(t *testing.T) {
+	data := createTestGIF(60, 40)
+
+	img, err := decodeFirstFrame(data, "image/gif", "test.gif")
+	if err != nil {
+		t.Fatalf("decodeFirstFrame(GIF) error = %v", err)
+	}
+
+	bounds := img.Bounds()
+	if bounds.Dx() != 60 || bounds.Dy() != 40 {
+		t.Errorf("decoded GIF first frame size = %dx%d, want 60x40", bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestDecodeFirstFrame_GIF_EmptyFrames(t *testing.T) {
+	// GIF with no frames
+	g := &gif.GIF{}
+	var buf bytes.Buffer
+	gif.EncodeAll(&buf, g)
+
+	_, err := decodeFirstFrame(buf.Bytes(), "image/gif", "empty.gif")
+	if err == nil {
+		t.Error("decodeFirstFrame() should error on empty GIF")
+	}
+}
+
+func TestGetStaticThumbnail(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	pngData := createTestPNG(400, 300)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(pngData)
+	}))
+	defer srv.Close()
+
+	cfg := DefaultThumbnailConfig()
+	path, err := GetStaticThumbnail(1, srv.URL+"/image.png", cfg)
+	if err != nil {
+		t.Fatalf("GetStaticThumbnail() error = %v", err)
+	}
+
+	if path == "" {
+		t.Fatal("GetStaticThumbnail() returned empty path")
+	}
+
+	// File should exist
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("thumbnail file not found: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("thumbnail file is empty")
+	}
+}
+
+func TestGetStaticThumbnail_Cached(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	callCount := 0
+	pngData := createTestPNG(200, 150)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(pngData)
+	}))
+	defer srv.Close()
+
+	cfg := DefaultThumbnailConfig()
+	url := srv.URL + "/cached.png"
+
+	// First call downloads
+	path1, err := GetStaticThumbnail(1, url, cfg)
+	if err != nil {
+		t.Fatalf("first call error = %v", err)
+	}
+
+	// Second call should use cache (no HTTP request)
+	path2, err := GetStaticThumbnail(1, url, cfg)
+	if err != nil {
+		t.Fatalf("second call error = %v", err)
+	}
+
+	if path1 != path2 {
+		t.Errorf("cached path mismatch: %q != %q", path1, path2)
+	}
+
+	if callCount != 1 {
+		t.Errorf("HTTP called %d times, want 1 (cached)", callCount)
+	}
+}
+
+func TestGetStaticThumbnail_InvalidInput(t *testing.T) {
+	cfg := DefaultThumbnailConfig()
+
+	// Invalid gameID
+	_, err := GetStaticThumbnail(0, "https://example.com/img.png", cfg)
+	if err == nil {
+		t.Error("should error on gameID 0")
+	}
+
+	// Empty URL
+	_, err = GetStaticThumbnail(1, "", cfg)
+	if err == nil {
+		t.Error("should error on empty URL")
+	}
+}
+
+func TestDefaultThumbnailConfig(t *testing.T) {
+	cfg := DefaultThumbnailConfig()
+
+	if cfg.MaxWidth != 200 {
+		t.Errorf("MaxWidth = %d, want 200", cfg.MaxWidth)
+	}
+	if cfg.MaxHeight != 0 {
+		t.Errorf("MaxHeight = %d, want 0 (proportional)", cfg.MaxHeight)
+	}
+	if cfg.Quality != 70 {
+		t.Errorf("Quality = %d, want 70", cfg.Quality)
+	}
+}
+
+func TestGetCachedThumbnailPath_NotCached(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	path := GetCachedThumbnailPath(1, "https://example.com/nonexistent.png")
+	if path != "" {
+		t.Errorf("GetCachedThumbnailPath() = %q, want empty for non-cached", path)
+	}
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,59 @@
+package version
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestVersionConstants(t *testing.T) {
+	// Major, Minor, Patch should be non-negative integers
+	if Major < 0 {
+		t.Errorf("Major = %d, want >= 0", Major)
+	}
+	if Minor < 0 {
+		t.Errorf("Minor = %d, want >= 0", Minor)
+	}
+	if Patch < 0 {
+		t.Errorf("Patch = %d, want >= 0", Patch)
+	}
+}
+
+func TestVersionFormat(t *testing.T) {
+	// Default (dev) version should contain major.minor.patch
+	expected := fmt.Sprintf("%d.%d.%d", Major, Minor, Patch)
+	if !strings.Contains(Version, expected) {
+		t.Errorf("Version = %q, want to contain %q", Version, expected)
+	}
+}
+
+func TestFull(t *testing.T) {
+	full := Full()
+
+	if full == "" {
+		t.Fatal("Full() returned empty string")
+	}
+
+	// Should contain the version string
+	if !strings.Contains(full, Version) {
+		t.Errorf("Full() = %q, want to contain Version %q", full, Version)
+	}
+
+	// Should contain the commit hash
+	if !strings.Contains(full, Commit) {
+		t.Errorf("Full() = %q, want to contain Commit %q", full, Commit)
+	}
+
+	// Should contain the build date
+	if !strings.Contains(full, BuildDate) {
+		t.Errorf("Full() = %q, want to contain BuildDate %q", full, BuildDate)
+	}
+}
+
+func TestFullFormat(t *testing.T) {
+	// Verify the exact format: "version (commit: hash, built: date)"
+	expected := fmt.Sprintf("%s (commit: %s, built: %s)", Version, Commit, BuildDate)
+	if got := Full(); got != expected {
+		t.Errorf("Full() = %q, want %q", got, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- Agrega 118 tests nuevos cubriendo 9 paquetes que tenían 0% de cobertura
- Usa el patrón existente: table-driven, `httptest.NewServer`, `t.TempDir()`, mock in-memory de `Storage`
- Todos pasan con `-race`

## Cobertura por paquete

| Paquete | Antes → Después |
|---------|-----------------|
| `pkg/version` | 0% → **100%** |
| `pkg/config` | 0% → **77%** |
| `pkg/steamgriddb` | 0% → **78%** |
| `agent/shortcuts` | 0% → **77%** |
| `agent/auth` | 0% → **79%** |
| `agent/server` | 0% → **5%** |
| `agent/config` | 0% → **93%** |
| `hub/config` | 0% → **82%** |
| `hub/auth` | 0% → **91%** |

## Test plan
- [x] `go test -race -count=1 ./...` — 274 tests pasan (118 nuevos)
- [x] CI ejecuta automáticamente al pushear

Closes #31