### PR TITLE
fix(agent): corregir memory leak CEF y eliminar duplicación

### DIFF
--- a/apps/agents/desktop/pathutil/expand.go
+++ b/apps/agents/desktop/pathutil/expand.go
@@ -1,0 +1,19 @@
+// Package pathutil provides shared path utilities for the desktop Agent.
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExpandHome expands ~ to the user's home directory.
+func ExpandHome(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}

--- a/apps/agents/desktop/server/server.go
+++ b/apps/agents/desktop/server/server.go
@@ -12,12 +12,12 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/lobinuxsoft/capydeploy/apps/agents/desktop/auth"
+	"github.com/lobinuxsoft/capydeploy/apps/agents/desktop/pathutil"
 	"github.com/lobinuxsoft/capydeploy/pkg/discovery"
 	"github.com/lobinuxsoft/capydeploy/pkg/protocol"
 	"github.com/lobinuxsoft/capydeploy/pkg/transfer"
@@ -288,7 +288,7 @@ func (s *Server) GetUploadPath(gameName, installPath string) string {
 	}
 
 	// Expand ~ to home directory
-	basePath = expandPath(basePath)
+	basePath = pathutil.ExpandHome(basePath)
 
 	return filepath.Join(basePath, gameName)
 }
@@ -301,18 +301,7 @@ func (s *Server) GetInstallPath() string {
 	} else {
 		path = s.cfg.UploadPath
 	}
-	return expandPath(path)
-}
-
-// expandPath expands ~ to the user's home directory.
-func expandPath(path string) string {
-	if strings.HasPrefix(path, "~/") {
-		home, err := os.UserHomeDir()
-		if err == nil {
-			return filepath.Join(home, path[2:])
-		}
-	}
-	return path
+	return pathutil.ExpandHome(path)
 }
 
 // NotifyShortcutChange calls the OnShortcutChange callback if set.

--- a/apps/agents/desktop/shortcuts/manager.go
+++ b/apps/agents/desktop/shortcuts/manager.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/lobinuxsoft/capydeploy/apps/agents/desktop/artwork"
+	"github.com/lobinuxsoft/capydeploy/apps/agents/desktop/pathutil"
 	agentSteam "github.com/lobinuxsoft/capydeploy/apps/agents/desktop/steam"
 	"github.com/lobinuxsoft/capydeploy/pkg/protocol"
 	"github.com/lobinuxsoft/capydeploy/pkg/steam"
@@ -135,8 +136,8 @@ func (m *Manager) List(userID string) ([]protocol.ShortcutInfo, error) {
 // The userID parameter is kept for signature compatibility but is not used
 // for creation — CEF handles persistence internally.
 func (m *Manager) Create(userID string, cfg protocol.ShortcutConfig) (uint32, error) {
-	exePath := expandPath(cfg.Exe)
-	startDir := expandPath(cfg.StartDir)
+	exePath := pathutil.ExpandHome(cfg.Exe)
+	startDir := pathutil.ExpandHome(cfg.StartDir)
 
 	// On Windows, Steam expects quoted paths
 	if runtime.GOOS == "windows" {
@@ -292,17 +293,6 @@ func (m *Manager) deleteArtwork(userID string, appID uint32) error {
 	return nil
 }
 
-// expandPath expands ~ to the user's home directory.
-func expandPath(path string) string {
-	if strings.HasPrefix(path, "~/") {
-		home, err := os.UserHomeDir()
-		if err == nil {
-			return filepath.Join(home, path[2:])
-		}
-	}
-	return path
-}
-
 // quotePath wraps a path in double quotes for Steam on Windows.
 // Linux shortcuts must NOT have quotes around paths.
 func quotePath(path string) string {
@@ -331,7 +321,7 @@ func deleteGameDirectory(path string) error {
 	}
 
 	// Expand path if it uses ~
-	path = expandPath(path)
+	path = pathutil.ExpandHome(path)
 
 	// Safety checks - don't delete system paths or root directories
 	absPath, err := filepath.Abs(path)

--- a/apps/agents/desktop/shortcuts/manager_test.go
+++ b/apps/agents/desktop/shortcuts/manager_test.go
@@ -8,13 +8,14 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/lobinuxsoft/capydeploy/apps/agents/desktop/pathutil"
 	"github.com/lobinuxsoft/capydeploy/pkg/protocol"
 	"github.com/lobinuxsoft/capydeploy/pkg/steam"
 )
 
 // --- Pure function tests ---
 
-func TestExpandPath(t *testing.T) {
+func TestExpandHome(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Skip("cannot determine home directory")
@@ -34,8 +35,8 @@ func TestExpandPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := expandPath(tt.path); got != tt.want {
-				t.Errorf("expandPath(%q) = %q, want %q", tt.path, got, tt.want)
+			if got := pathutil.ExpandHome(tt.path); got != tt.want {
+				t.Errorf("ExpandHome(%q) = %q, want %q", tt.path, got, tt.want)
 			}
 		})
 	}

--- a/apps/agents/desktop/steam/control.go
+++ b/apps/agents/desktop/steam/control.go
@@ -1,6 +1,21 @@
 // Package steam provides Steam control operations for the Agent.
 package steam
 
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	// cefTimeout is the max time to wait for CEF to be available.
+	cefTimeout = 30 * time.Second
+	// cefCheckInterval is the interval between CEF availability checks.
+	cefCheckInterval = 2 * time.Second
+	// shutdownTimeout is the max time to wait for Steam to close.
+	shutdownTimeout = 10 * time.Second
+)
+
 // Controller manages Steam process operations.
 type Controller struct{}
 
@@ -13,4 +28,45 @@ func NewController() *Controller {
 type RestartResult struct {
 	Success bool   `json:"success"`
 	Message string `json:"message"`
+}
+
+// IsCEFAvailable checks if Steam's CEF debugger is responding.
+func (c *Controller) IsCEFAvailable() bool {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(cefDebugEndpoint)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// WaitForCEF waits until Steam's CEF debugger is available or timeout.
+func (c *Controller) WaitForCEF() error {
+	deadline := time.Now().Add(cefTimeout)
+
+	for time.Now().Before(deadline) {
+		if c.IsCEFAvailable() {
+			return nil
+		}
+		time.Sleep(cefCheckInterval)
+	}
+
+	return fmt.Errorf("timeout waiting for Steam CEF (waited %v)", cefTimeout)
+}
+
+// EnsureRunning makes sure Steam is running and CEF is available.
+// If Steam is not running, it starts it and waits for CEF.
+func (c *Controller) EnsureRunning() error {
+	if c.IsCEFAvailable() {
+		return nil
+	}
+
+	if !c.IsRunning() {
+		if err := c.Start(); err != nil {
+			return err
+		}
+	}
+
+	return c.WaitForCEF()
 }


### PR DESCRIPTION
## Summary
- Corrige memory leak en `evaluateAsync`: goroutine que cierra el WS al cancelar el contexto para desbloquear `ReadMessage` (issue #67 item #9)
- Extrae helper `eval()` en `CEFClient` eliminando el preámbulo `getTabs+findJSContext` repetido 7 veces
- Mueve `IsCEFAvailable`/`WaitForCEF`/`EnsureRunning` + 4 constantes de `control_linux.go` y `control_windows.go` a `control.go` (código era idéntico)
- Unifica constante `cefEndpoint` duplicada con `cefDebugEndpoint` existente en `cef.go`
- Extrae `expandPath()` duplicada en `server/server.go` y `shortcuts/manager.go` al nuevo paquete `pathutil.ExpandHome()`

**Resultado neto: -106 líneas** (122 insertadas, 228 eliminadas)

## Test plan
- [x] `go vet -tags webkit2_41 ./apps/agents/desktop/...` — sin errores
- [x] `go test ./apps/agents/desktop/...` — todos los tests pasan
- [x] `go test ./apps/hub/... ./pkg/...` — sin regresiones
- [x] Verificar que `cefEndpoint` ya no existe (unificada con `cefDebugEndpoint`)

Closes #67