### PR TITLE
refactor(core): eliminar duplicados menores e implementar cleanup

### DIFF
--- a/apps/agents/decky/artwork.py
+++ b/apps/agents/decky/artwork.py
@@ -8,8 +8,6 @@ import base64
 import os
 import ssl
 import urllib.request
-from typing import Optional
-
 import decky  # type: ignore
 
 from steam_utils import get_steam_dir, get_steam_users
@@ -32,6 +30,83 @@ _EXT_MAP = {
     "image/jpeg": "jpg",
     "image/webp": "webp",
 }
+
+
+def _make_ssl_context() -> ssl.SSLContext:
+    """Create an SSL context with best-effort certificate loading.
+
+    Decky Loader runs as root with its own Python — the system cert store
+    may not be configured.  We try to load certs, and if the store is empty,
+    we disable verification so CDN downloads still work.
+    """
+    ctx = ssl.create_default_context()
+    try:
+        ctx.load_default_certs()
+    except Exception:
+        pass
+    if not ctx.get_ca_certs():
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+async def _update_vdf_icon(vdf_path: str, app_id: int, icon_path: str) -> bool:
+    """Update shortcuts.vdf to set the icon path for a shortcut.
+
+    Retries with exponential backoff because Steam may not have flushed
+    the new shortcut to shortcuts.vdf yet after AddShortcut().
+    Returns True if the VDF was successfully updated.
+    """
+    try:
+        from vdf import binary_load, binary_dump
+    except ImportError:
+        decky.logger.error("vdf package not found, cannot set shortcut icon")
+        return False
+
+    for attempt in range(MAX_ICON_RETRIES):
+        if not os.path.exists(vdf_path):
+            delay = ICON_RETRY_BASE_DELAY * (2 ** attempt)
+            decky.logger.info(
+                f"shortcuts.vdf not found yet, retry {attempt + 1}/{MAX_ICON_RETRIES} in {delay}s"
+            )
+            await asyncio.sleep(delay)
+            continue
+
+        try:
+            with open(vdf_path, "rb") as f:
+                data = binary_load(f)
+
+            found = False
+            for shortcut in data.get("shortcuts", {}).values():
+                vdf_appid = (shortcut.get("appid", 0) & 0xFFFFFFFF) | 0x80000000
+                if vdf_appid == app_id:
+                    shortcut["icon"] = icon_path
+                    found = True
+                    break
+
+            if found:
+                with open(vdf_path, "wb") as f:
+                    binary_dump(data, f)
+                decky.logger.info(f"Updated shortcuts.vdf icon for appId={app_id}")
+                return True
+
+            # VDF exists but shortcut not in it yet — Steam hasn't flushed
+            delay = ICON_RETRY_BASE_DELAY * (2 ** attempt)
+            decky.logger.info(
+                f"Shortcut appId={app_id} not in VDF yet, retry {attempt + 1}/{MAX_ICON_RETRIES} in {delay}s"
+            )
+            await asyncio.sleep(delay)
+
+        except Exception as e:
+            decky.logger.error(f"Failed to update shortcuts.vdf (attempt {attempt + 1}): {e}")
+            delay = ICON_RETRY_BASE_DELAY * (2 ** attempt)
+            await asyncio.sleep(delay)
+
+    decky.logger.warning(
+        f"Could not update shortcuts.vdf for appId={app_id} after {MAX_ICON_RETRIES} retries. "
+        f"Icon file saved at {icon_path}, will apply on Steam restart."
+    )
+    return False
 
 
 def apply_from_data(app_id: int, artwork_type: str, data: bytes, content_type: str) -> None:
@@ -83,16 +158,7 @@ def apply_from_data(app_id: int, artwork_type: str, data: bytes, content_type: s
 
 async def download_artwork(artwork: dict) -> dict:
     """Download artwork URLs and return base64-encoded data with format info."""
-    # Decky runs as root with its own Python — SSL certs may not be configured
-    ssl_ctx = ssl.create_default_context()
-    try:
-        ssl_ctx.load_default_certs()
-    except Exception:
-        pass
-    # Fallback: if cert store is empty, disable verification for CDN downloads
-    if not ssl_ctx.get_ca_certs():
-        ssl_ctx.check_hostname = False
-        ssl_ctx.verify_mode = ssl.CERT_NONE
+    ssl_ctx = _make_ssl_context()
 
     result = {}
     for key in ("grid", "hero", "logo", "banner"):
@@ -127,12 +193,6 @@ async def set_shortcut_icon(app_id: int, icon_b64: str, icon_format: str) -> boo
     the new shortcut to shortcuts.vdf yet when this is called right after
     AddShortcut().
     """
-    try:
-        from vdf import binary_load, binary_dump
-    except ImportError:
-        decky.logger.error("vdf package not found, cannot set shortcut icon")
-        return False
-
     steam_dir = get_steam_dir()
     if not steam_dir:
         decky.logger.error("Steam directory not found")
@@ -162,52 +222,7 @@ async def set_shortcut_icon(app_id: int, icon_b64: str, icon_format: str) -> boo
 
     # 2. Update shortcuts.vdf with retry (race condition: Steam hasn't flushed yet)
     vdf_path = os.path.join(steam_dir, "userdata", user_id, "config", "shortcuts.vdf")
-
-    for attempt in range(MAX_ICON_RETRIES):
-        if not os.path.exists(vdf_path):
-            delay = ICON_RETRY_BASE_DELAY * (2 ** attempt)
-            decky.logger.info(
-                f"shortcuts.vdf not found yet, retry {attempt + 1}/{MAX_ICON_RETRIES} in {delay}s"
-            )
-            await asyncio.sleep(delay)
-            continue
-
-        try:
-            with open(vdf_path, "rb") as f:
-                data = binary_load(f)
-
-            found = False
-            for shortcut in data.get("shortcuts", {}).values():
-                vdf_appid = (shortcut.get("appid", 0) & 0xFFFFFFFF) | 0x80000000
-                if vdf_appid == app_id:
-                    shortcut["icon"] = icon_path
-                    found = True
-                    break
-
-            if found:
-                with open(vdf_path, "wb") as f:
-                    binary_dump(data, f)
-                decky.logger.info(f"Updated shortcuts.vdf icon for appId={app_id}")
-                return True
-
-            # VDF exists but shortcut not in it yet — Steam hasn't flushed
-            delay = ICON_RETRY_BASE_DELAY * (2 ** attempt)
-            decky.logger.info(
-                f"Shortcut appId={app_id} not in VDF yet, retry {attempt + 1}/{MAX_ICON_RETRIES} in {delay}s"
-            )
-            await asyncio.sleep(delay)
-
-        except Exception as e:
-            decky.logger.error(f"Failed to update shortcuts.vdf (attempt {attempt + 1}): {e}")
-            delay = ICON_RETRY_BASE_DELAY * (2 ** attempt)
-            await asyncio.sleep(delay)
-
-    # All retries exhausted — icon file is saved in grid/, Steam restart will pick it up
-    decky.logger.warning(
-        f"Could not update shortcuts.vdf for appId={app_id} after {MAX_ICON_RETRIES} retries. "
-        f"Icon file saved at {icon_path}, will apply on Steam restart."
-    )
-    return False
+    return await _update_vdf_icon(vdf_path, app_id, icon_path)
 
 
 async def set_shortcut_icon_from_url(app_id: int, icon_url: str) -> bool:
@@ -217,12 +232,6 @@ async def set_shortcut_icon_from_url(app_id: int, icon_url: str) -> bool:
     updates shortcuts.vdf. Preserves the original file extension from the URL.
     """
     from urllib.parse import urlparse
-
-    try:
-        from vdf import binary_load, binary_dump
-    except ImportError:
-        decky.logger.error("vdf package not found, cannot set shortcut icon")
-        return False
 
     steam_dir = get_steam_dir()
     if not steam_dir:
@@ -245,14 +254,7 @@ async def set_shortcut_icon_from_url(app_id: int, icon_url: str) -> bool:
     icon_path = os.path.join(grid_dir, icon_filename)
 
     # Download directly to file
-    ssl_ctx = ssl.create_default_context()
-    try:
-        ssl_ctx.load_default_certs()
-    except Exception:
-        pass
-    if not ssl_ctx.get_ca_certs():
-        ssl_ctx.check_hostname = False
-        ssl_ctx.verify_mode = ssl.CERT_NONE
+    ssl_ctx = _make_ssl_context()
 
     try:
         req = urllib.request.Request(icon_url, headers={"User-Agent": "CapyDeploy/0.1"})
@@ -267,47 +269,4 @@ async def set_shortcut_icon_from_url(app_id: int, icon_url: str) -> bool:
 
     # Update shortcuts.vdf with retry
     vdf_path = os.path.join(steam_dir, "userdata", user_id, "config", "shortcuts.vdf")
-
-    for attempt in range(MAX_ICON_RETRIES):
-        if not os.path.exists(vdf_path):
-            delay = ICON_RETRY_BASE_DELAY * (2 ** attempt)
-            decky.logger.info(
-                f"shortcuts.vdf not found yet, retry {attempt + 1}/{MAX_ICON_RETRIES} in {delay}s"
-            )
-            await asyncio.sleep(delay)
-            continue
-
-        try:
-            with open(vdf_path, "rb") as f:
-                vdf_data = binary_load(f)
-
-            found = False
-            for shortcut in vdf_data.get("shortcuts", {}).values():
-                vdf_appid = (shortcut.get("appid", 0) & 0xFFFFFFFF) | 0x80000000
-                if vdf_appid == app_id:
-                    shortcut["icon"] = icon_path
-                    found = True
-                    break
-
-            if found:
-                with open(vdf_path, "wb") as f:
-                    binary_dump(vdf_data, f)
-                decky.logger.info(f"Updated shortcuts.vdf icon for appId={app_id}")
-                return True
-
-            delay = ICON_RETRY_BASE_DELAY * (2 ** attempt)
-            decky.logger.info(
-                f"Shortcut appId={app_id} not in VDF yet, retry {attempt + 1}/{MAX_ICON_RETRIES} in {delay}s"
-            )
-            await asyncio.sleep(delay)
-
-        except Exception as e:
-            decky.logger.error(f"Failed to update shortcuts.vdf (attempt {attempt + 1}): {e}")
-            delay = ICON_RETRY_BASE_DELAY * (2 ** attempt)
-            await asyncio.sleep(delay)
-
-    decky.logger.warning(
-        f"Could not update shortcuts.vdf for appId={app_id} after {MAX_ICON_RETRIES} retries. "
-        f"Icon file saved at {icon_path}, will apply on Steam restart."
-    )
-    return False
+    return await _update_vdf_icon(vdf_path, app_id, icon_path)

--- a/apps/agents/decky/main.py
+++ b/apps/agents/decky/main.py
@@ -61,6 +61,7 @@ class Plugin:
             name="capydeploy",
             settings_directory=decky.DECKY_PLUGIN_SETTINGS_DIR
         )
+        self.version = PLUGIN_VERSION
         self.pairing = PairingManager(self.settings)
         self.ws_server = WebSocketServer(self)
         self.mdns_service = None

--- a/apps/agents/desktop/app.go
+++ b/apps/agents/desktop/app.go
@@ -606,20 +606,9 @@ func (a *App) getAddress() string {
 // Helper functions
 // =============================================================================
 
-// VersionInfo represents version information for the frontend.
-type VersionInfo struct {
-	Version   string `json:"version"`
-	Commit    string `json:"commit"`
-	BuildDate string `json:"buildDate"`
-}
-
 // GetVersion returns the current version information.
-func (a *App) GetVersion() VersionInfo {
-	return VersionInfo{
-		Version:   version.Version,
-		Commit:    version.Commit,
-		BuildDate: version.BuildDate,
-	}
+func (a *App) GetVersion() version.Info {
+	return version.GetInfo()
 }
 
 // CapabilityInfo represents a capability for the frontend.

--- a/apps/agents/desktop/server/upload.go
+++ b/apps/agents/desktop/server/upload.go
@@ -293,11 +293,16 @@ func (s *Server) handleCancelUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	gamePath := s.GetUploadPath(session.Config.GameName, session.Config.InstallPath)
 	session.Cancel()
 	s.DeleteUpload(uploadID)
 
-	// TODO: Clean up partial files
-	log.Printf("Upload cancelled: %s", uploadID)
+	// Clean up partial files left on disk
+	if err := os.RemoveAll(gamePath); err != nil {
+		log.Printf("Warning: failed to clean up partial upload at %s: %v", gamePath, err)
+	}
+
+	log.Printf("Upload cancelled: %s (cleaned %s)", uploadID, gamePath)
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"status": "cancelled"})

--- a/apps/agents/desktop/server/wsserver.go
+++ b/apps/agents/desktop/server/wsserver.go
@@ -54,8 +54,8 @@ func NewWSServer(s *Server, authMgr *auth.Manager, onConnect func(string, string
 		server:  s,
 		authMgr: authMgr,
 		upgrader: websocket.Upgrader{
-			ReadBufferSize:  1024,
-			WriteBufferSize: 1024,
+			ReadBufferSize:  64 * 1024,
+			WriteBufferSize: 64 * 1024,
 			CheckOrigin: func(r *http.Request) bool {
 				return true // Allow all origins for local network
 			},

--- a/apps/hub/app.go
+++ b/apps/hub/app.go
@@ -984,20 +984,9 @@ func (a *App) GetIcons(gameID int, filters steamgriddb.ImageFilters, page int) (
 // Version
 // =============================================================================
 
-// VersionInfo represents version information for the frontend.
-type VersionInfo struct {
-	Version   string `json:"version"`
-	Commit    string `json:"commit"`
-	BuildDate string `json:"buildDate"`
-}
-
 // GetVersion returns the current version information.
-func (a *App) GetVersion() VersionInfo {
-	return VersionInfo{
-		Version:   version.Version,
-		Commit:    version.Commit,
-		BuildDate: version.BuildDate,
-	}
+func (a *App) GetVersion() version.Info {
+	return version.GetInfo()
 }
 
 // =============================================================================

--- a/pkg/steamgriddb/client.go
+++ b/pkg/steamgriddb/client.go
@@ -77,15 +77,9 @@ func (c *Client) GetGrids(gameID int, filters *ImageFilters, page int) ([]GridDa
 		return nil, err
 	}
 
-	var resp gridResponse
+	var resp imageResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return nil, err
-	}
-
-	// Debug: log first result
-	if len(resp.Data) > 0 {
-		fmt.Printf("[DEBUG] First grid: URL=%s, Thumb=%s, %dx%d\n",
-			resp.Data[0].URL, resp.Data[0].Thumb, resp.Data[0].Width, resp.Data[0].Height)
 	}
 
 	return resp.Data, nil

--- a/pkg/steamgriddb/client_test.go
+++ b/pkg/steamgriddb/client_test.go
@@ -81,9 +81,9 @@ func TestGetGrids(t *testing.T) {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 
-		resp := gridResponse{
+		resp := imageResponse{
 			apiResponse: apiResponse{Success: true},
-			Data: []GridData{
+			Data: []ImageData{
 				{ID: 100, URL: "https://example.com/grid.png", Width: 920, Height: 430},
 			},
 		}

--- a/pkg/steamgriddb/types.go
+++ b/pkg/steamgriddb/types.go
@@ -9,26 +9,7 @@ type SearchResult struct {
 	Verified bool     `json:"verified"`
 }
 
-// GridData represents a grid image
-type GridData struct {
-	ID        int    `json:"id"`
-	Score     int    `json:"score"`
-	Style     string `json:"style"`
-	Width     int    `json:"width"`
-	Height    int    `json:"height"`
-	Nsfw      bool   `json:"nsfw"`
-	Humor     bool   `json:"humor"`
-	Mime      string `json:"mime"`
-	Language  string `json:"language"`
-	URL       string `json:"url"`
-	Thumb     string `json:"thumb"`
-	Lock      bool   `json:"lock"`
-	Epilepsy  bool   `json:"epilepsy"`
-	Upvotes   int    `json:"upvotes"`
-	Downvotes int    `json:"downvotes"`
-}
-
-// ImageData represents a hero/logo/icon image
+// ImageData represents a SteamGridDB image (grid, hero, logo, or icon).
 type ImageData struct {
 	ID        int    `json:"id"`
 	Score     int    `json:"score"`
@@ -46,6 +27,9 @@ type ImageData struct {
 	Upvotes   int    `json:"upvotes"`
 	Downvotes int    `json:"downvotes"`
 }
+
+// GridData is an alias for ImageData (grids share the same API schema).
+type GridData = ImageData
 
 // ImageFilters represents filters for image queries
 type ImageFilters struct {
@@ -66,11 +50,6 @@ type apiResponse struct {
 type searchResponse struct {
 	apiResponse
 	Data []SearchResult `json:"data"`
-}
-
-type gridResponse struct {
-	apiResponse
-	Data []GridData `json:"data"`
 }
 
 type imageResponse struct {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -29,3 +29,19 @@ var (
 func Full() string {
 	return fmt.Sprintf("%s (commit: %s, built: %s)", Version, Commit, BuildDate)
 }
+
+// Info represents version information for frontend consumption.
+type Info struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildDate string `json:"buildDate"`
+}
+
+// GetInfo returns the current version information.
+func GetInfo() Info {
+	return Info{
+		Version:   Version,
+		Commit:    Commit,
+		BuildDate: BuildDate,
+	}
+}


### PR DESCRIPTION
## Summary
- Unifica `GridData`/`ImageData` en steamgriddb (eran structs idénticos) mediante alias
- Extrae `buildBinaryMessage`/`sendBinary` en wsclient eliminando construcción de mensaje binario 2x duplicada
- Mueve `VersionInfo` a `pkg/version.Info`, elimina copias en hub/app.go y agent/app.go
- Aumenta WS buffer de 1KB a 64KB en agent desktop wsserver
- Implementa cleanup de archivos parciales al cancelar uploads (tanto HTTP como WS path)
- Elimina `fmt.Printf` de debug olvidado en steamgriddb `GetGrids`
- **Decky**: extrae `_make_ssl_context()`, `_update_vdf_icon()`, `_write_chunk()` eliminando 3 bloques duplicados
- **Decky**: reemplaza versión hardcoded `"0.1.0"` por `plugin.version` dinámico

**Resultado neto: -89 líneas** (165 insertadas, 254 eliminadas) en 13 archivos

## Test plan
- [x] `go vet -tags webkit2_41 ./...` — sin errores
- [x] `go test -tags webkit2_41 ./...` — todos los tests pasan
- [x] `GridData` sigue siendo usable vía alias (backwards compatible)
- [x] Verificar que no quedan `"0.1.0"` hardcoded en ws_server.py

Closes #67