### PR TITLE
refactor(agent): unificar tipos AuthorizedHub entre config y auth

### DIFF
--- a/apps/agents/desktop/auth/storage.go
+++ b/apps/agents/desktop/auth/storage.go
@@ -26,8 +26,8 @@ func (s *ConfigStorageAdapter) GetAuthorizedHubs() []AuthorizedHub {
 			Name:     h.Name,
 			Platform: h.Platform,
 			Token:    h.Token,
-			PairedAt: parseTime(h.PairedAt),
-			LastSeen: parseTime(h.LastSeen),
+			PairedAt: h.PairedAt,
+			LastSeen: h.LastSeen,
 		}
 	}
 	return hubs
@@ -40,8 +40,8 @@ func (s *ConfigStorageAdapter) AddAuthorizedHub(hub AuthorizedHub) error {
 		Name:     hub.Name,
 		Platform: hub.Platform,
 		Token:    hub.Token,
-		PairedAt: hub.PairedAt.Format(time.RFC3339),
-		LastSeen: hub.LastSeen.Format(time.RFC3339),
+		PairedAt: hub.PairedAt,
+		LastSeen: hub.LastSeen,
 	}
 	return s.cfg.AddAuthorizedHub(cfgHub)
 }
@@ -53,15 +53,10 @@ func (s *ConfigStorageAdapter) RemoveAuthorizedHub(hubID string) error {
 
 // UpdateHubLastSeen updates the LastSeen timestamp for a Hub.
 func (s *ConfigStorageAdapter) UpdateHubLastSeen(hubID string, lastSeen time.Time) error {
-	return s.cfg.UpdateHubLastSeen(hubID, lastSeen.Format(time.RFC3339))
+	return s.cfg.UpdateHubLastSeen(hubID, lastSeen)
 }
 
 // Save persists the storage (no-op, config saves on each change).
 func (s *ConfigStorageAdapter) Save() error {
 	return nil
-}
-
-func parseTime(s string) time.Time {
-	t, _ := time.Parse(time.RFC3339, s)
-	return t
 }

--- a/apps/agents/desktop/config/config.go
+++ b/apps/agents/desktop/config/config.go
@@ -6,18 +6,19 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/lobinuxsoft/capydeploy/pkg/discovery"
 )
 
 // AuthorizedHub represents a Hub that has been paired with this Agent.
 type AuthorizedHub struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Platform string `json:"platform,omitempty"`
-	Token    string `json:"token"`
-	PairedAt string `json:"pairedAt"`
-	LastSeen string `json:"lastSeen"`
+	ID       string    `json:"id"`
+	Name     string    `json:"name"`
+	Platform string    `json:"platform,omitempty"`
+	Token    string    `json:"token"`
+	PairedAt time.Time `json:"pairedAt"`
+	LastSeen time.Time `json:"lastSeen"`
 }
 
 // Config holds the agent configuration.
@@ -179,7 +180,7 @@ func (m *Manager) RemoveAuthorizedHub(hubID string) error {
 }
 
 // UpdateHubLastSeen updates the LastSeen timestamp for a Hub.
-func (m *Manager) UpdateHubLastSeen(hubID string, lastSeen string) error {
+func (m *Manager) UpdateHubLastSeen(hubID string, lastSeen time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/apps/agents/desktop/config/config_test.go
+++ b/apps/agents/desktop/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestNewManager(t *testing.T) {
@@ -227,13 +228,14 @@ func TestUpdateHubLastSeen(t *testing.T) {
 
 	mgr.AddAuthorizedHub(AuthorizedHub{ID: "hub-1", Name: "Hub"})
 
-	if err := mgr.UpdateHubLastSeen("hub-1", "2025-01-15T10:30:00Z"); err != nil {
+	lastSeen := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	if err := mgr.UpdateHubLastSeen("hub-1", lastSeen); err != nil {
 		t.Fatalf("UpdateHubLastSeen() error = %v", err)
 	}
 
 	hubs := mgr.GetAuthorizedHubs()
-	if len(hubs) != 1 || hubs[0].LastSeen != "2025-01-15T10:30:00Z" {
-		t.Errorf("hub LastSeen = %q, want %q", hubs[0].LastSeen, "2025-01-15T10:30:00Z")
+	if len(hubs) != 1 || !hubs[0].LastSeen.Equal(lastSeen) {
+		t.Errorf("hub LastSeen = %v, want %v", hubs[0].LastSeen, lastSeen)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Cambiar `config.AuthorizedHub.PairedAt` y `LastSeen` de `string` a `time.Time` para alinear con `auth.AuthorizedHub`
- Eliminar `parseTime()` y conversiones `Format(time.RFC3339)` innecesarias en `ConfigStorageAdapter`
- Actualizar `UpdateHubLastSeen()` para recibir `time.Time` directo

## JSON backward-compatible
`time.Time` con tag `json:"pairedAt"` serializa como `"2025-01-15T10:30:00Z"` — mismo formato RFC3339 que el string anterior. Los configs existentes en disco se parsean correctamente.

## Test plan
- [x] `go vet -tags webkit2_41 ./apps/agents/desktop/...` pasa
- [x] `go test ./apps/agents/desktop/...` pasa (config + auth + todos)
- [x] Verificar que no hay otros callers de `UpdateHubLastSeen` con string

Closes #67