### PR TITLE
fix(ci): disparar release solo desde release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+  release:
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Cambiar trigger de `release.yml` de `push: tags` a `release: published`
- Solo release-please puede disparar builds de release (al mergear el Release PR)
- Tags manuales ya no disparan el pipeline

## Antes vs Ahora

| | Antes | Ahora |
|---|---|---|
| **Trigger** | `push: tags: v*` | `release: published` |
| **Tag manual** | Dispara release | No pasa nada |
| **release-please** | Crea tag → dispara | Crea release → dispara |

## Test plan
- [x] `GITHUB_REF_NAME` sigue disponible con evento `release: published`
- [x] Los 3 usos de `GITHUB_REF_NAME` en release.yml siguen funcionando
- [x] No hay cambios en Go — solo YAML