### PR TITLE
docs: separar flujo de descarga del build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,23 @@ CapyDeploy is a cross-platform tool for uploading and managing games on Steam De
 | **Agent** | Runs on handheld (desktop mode). Receives games, creates Steam shortcuts, applies artwork, restarts Steam. |
 | **Decky Plugin** | Runs inside [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader) (gaming mode). Same protocol as Agent but uses SteamClient APIs directly — no Steam restart needed. |
 
-## Requirements
+## Download
 
-### Building
+Pre-built binaries are available for each release:
+
+| Component | Linux | Windows |
+|-----------|-------|---------|
+| **Hub** (your PC) | AppImage | ZIP |
+| **Agent** (handheld) | AppImage | ZIP |
+| **Decky Plugin** (gaming mode) | ZIP | — |
+
+**[Download Latest Release](https://github.com/lobinuxsoft/capydeploy/releases/latest)** · [All releases](https://github.com/lobinuxsoft/capydeploy/releases)
+
+See the [Installation Guide](https://lobinuxsoft.github.io/capydeploy/install) for platform-specific instructions.
+
+## Building from Source (for contributors)
+
+### Requirements
 - Go 1.24+
 - Bun: https://bun.sh
 - Wails CLI: `go install github.com/wailsapp/wails/v2/cmd/wails@latest`
@@ -71,7 +85,7 @@ CapyDeploy is a cross-platform tool for uploading and managing games on Steam De
 | Arch | `pacman -S webkit2gtk gtk3` |
 | Windows | WebView2 (pre-installed on Win10/11) |
 
-## Building
+### Build
 
 ```bash
 # Clone

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,10 +33,13 @@ title: Home
       Perfect for game development testing, DRM-free game collections (GOG, itch.io), and retro gaming.
     </p>
     <div class="flex flex-col sm:flex-row gap-4 justify-center">
-      <a href="{{ '/usage' | relative_url }}" class="px-8 py-4 rounded-xl bg-gradient-to-r from-capy-500 to-capy-600 text-white font-semibold hover:from-capy-600 hover:to-capy-700 transition shadow-lg shadow-capy-500/25">
-        Get Started
+      <a href="{{ '/install' | relative_url }}" class="px-8 py-4 rounded-xl bg-gradient-to-r from-capy-500 to-capy-600 text-white font-semibold hover:from-capy-600 hover:to-capy-700 transition shadow-lg shadow-capy-500/25">
+        Download
       </a>
-      <a href="{{ '/architecture' | relative_url }}" class="px-8 py-4 rounded-xl bg-slate-800 text-slate-200 font-semibold hover:bg-slate-700 transition border border-slate-700">
+      <a href="{{ '/usage' | relative_url }}" class="px-8 py-4 rounded-xl bg-slate-800 text-slate-200 font-semibold hover:bg-slate-700 transition border border-slate-700">
+        Usage Guide
+      </a>
+      <a href="{{ '/architecture' | relative_url }}" class="px-8 py-4 rounded-xl bg-slate-800/50 text-slate-400 font-semibold hover:bg-slate-700 transition border border-slate-700/50">
         How it Works
       </a>
     </div>

--- a/docs/install.html
+++ b/docs/install.html
@@ -2,10 +2,142 @@
 layout: default
 title: Installation
 ---
+<!-- Download Section (for users) -->
 <section class="py-20 px-4 pt-32">
   <div class="max-w-4xl mx-auto">
-    <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">Installation</h2>
-    <p class="text-slate-400 text-center mb-12">Get CapyDeploy running in a few steps.</p>
+    <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">Download</h2>
+    <p class="text-slate-400 text-center mb-12">Pre-built binaries ready to use. No compilation required.</p>
+
+    <!-- Download Cards -->
+    <div class="grid md:grid-cols-3 gap-6 mb-12">
+      <!-- Hub -->
+      <div class="bg-slate-900/50 border border-capy-500/20 rounded-2xl p-6 flex flex-col">
+        <div class="w-12 h-12 rounded-xl bg-capy-500/10 flex items-center justify-center mb-4">
+          <svg class="w-6 h-6 text-capy-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+          </svg>
+        </div>
+        <h3 class="text-lg font-semibold mb-2">Hub <span class="text-sm text-slate-500 font-normal">(Your PC)</span></h3>
+        <p class="text-slate-400 text-sm mb-4 flex-1">Discovers agents, sends games, manages your library.</p>
+        <div class="space-y-2 text-sm">
+          <span class="block text-slate-500">Available as:</span>
+          <span class="inline-block px-2 py-1 rounded bg-green-500/10 text-green-400 text-xs">Linux AppImage</span>
+          <span class="inline-block px-2 py-1 rounded bg-blue-500/10 text-blue-400 text-xs">Windows ZIP</span>
+        </div>
+      </div>
+
+      <!-- Agent -->
+      <div class="bg-slate-900/50 border border-water-500/20 rounded-2xl p-6 flex flex-col">
+        <div class="w-12 h-12 rounded-xl bg-water-500/10 flex items-center justify-center mb-4">
+          <svg class="w-6 h-6 text-water-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+          </svg>
+        </div>
+        <h3 class="text-lg font-semibold mb-2">Agent <span class="text-sm text-slate-500 font-normal">(Handheld)</span></h3>
+        <p class="text-slate-400 text-sm mb-4 flex-1">Receives games, creates Steam shortcuts, applies artwork.</p>
+        <div class="space-y-2 text-sm">
+          <span class="block text-slate-500">Available as:</span>
+          <span class="inline-block px-2 py-1 rounded bg-green-500/10 text-green-400 text-xs">Linux AppImage</span>
+          <span class="inline-block px-2 py-1 rounded bg-blue-500/10 text-blue-400 text-xs">Windows ZIP</span>
+        </div>
+      </div>
+
+      <!-- Decky Plugin -->
+      <div class="bg-slate-900/50 border border-purple-500/20 rounded-2xl p-6 flex flex-col">
+        <div class="w-12 h-12 rounded-xl bg-purple-500/10 flex items-center justify-center mb-4">
+          <svg class="w-6 h-6 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/>
+          </svg>
+        </div>
+        <h3 class="text-lg font-semibold mb-2">Decky Plugin <span class="text-sm text-slate-500 font-normal">(Gaming Mode)</span></h3>
+        <p class="text-slate-400 text-sm mb-4 flex-1">Alternative Agent inside <a href="https://github.com/SteamDeckHomebrew/decky-loader" class="text-purple-400 hover:underline">Decky Loader</a>. No Steam restart needed.</p>
+        <div class="space-y-2 text-sm">
+          <span class="block text-slate-500">Available as:</span>
+          <span class="inline-block px-2 py-1 rounded bg-purple-500/10 text-purple-400 text-xs">ZIP (Decky plugin)</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Download Button -->
+    <div class="text-center mb-16">
+      <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest" class="inline-flex items-center gap-2 px-8 py-4 rounded-xl bg-gradient-to-r from-capy-500 to-capy-600 text-white font-semibold hover:from-capy-600 hover:to-capy-700 transition shadow-lg shadow-capy-500/25">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+        Download Latest Release
+      </a>
+      <p class="text-slate-500 text-sm mt-3">
+        <a href="https://github.com/lobinuxsoft/capydeploy/releases" class="hover:text-slate-300 transition">Browse all releases &rarr;</a>
+      </p>
+    </div>
+
+    <!-- Platform Install Instructions -->
+    <div class="grid md:grid-cols-3 gap-6 mb-16">
+      <!-- Linux -->
+      <div class="bg-slate-900 border border-slate-800 rounded-2xl p-6">
+        <h4 class="font-semibold text-green-400 mb-3 flex items-center gap-2">
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.368 1.884 1.43.585.047 1.042-.245 1.484-.93.4-.644.752-1.474.939-2.386.029-.143.057-.26.127-.397.063-.119.185-.277.316-.333.349-.153.561-.347.672-.628.117-.282.127-.627.049-1.084-.058-.328-.63-1.256-.12-1.593.488-.31 1.44-1.147 1.852-2.238.191-.555.203-1.16.042-1.775-.162-.607-.543-1.233-.959-1.7-.816-.936-1.658-1.244-2.123-1.79-.455-.533-.636-1.15-.702-1.75-.065-.572.004-1.134-.074-1.7C17.1 1.894 14.897.003 12.504 0z"/></svg>
+          Linux
+        </h4>
+        <div class="text-sm text-slate-400 space-y-2">
+          <p>1. Download the <code class="text-capy-400">.AppImage</code> file</p>
+          <p>2. Make it executable:</p>
+          <div class="bg-slate-950 rounded-lg p-3 mt-1">
+            <code class="text-xs text-slate-300">chmod +x CapyDeploy_*.AppImage</code>
+          </div>
+          <p>3. Run it &mdash; it will prompt to install automatically</p>
+          <div class="mt-3 text-xs text-slate-500">
+            <p>Installs to <code>~/.local/bin/</code> with desktop entry and icon.</p>
+            <p class="mt-1">CLI: <code>--install</code>, <code>--uninstall</code>, <code>--help</code></p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Windows -->
+      <div class="bg-slate-900 border border-slate-800 rounded-2xl p-6">
+        <h4 class="font-semibold text-blue-400 mb-3 flex items-center gap-2">
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/></svg>
+          Windows
+        </h4>
+        <div class="text-sm text-slate-400 space-y-2">
+          <p>1. Download the <code class="text-capy-400">.zip</code> file</p>
+          <p>2. Extract the ZIP</p>
+          <p>3. Run <code class="text-capy-400">capydeploy-hub.exe</code> or <code class="text-capy-400">capydeploy-agent.exe</code></p>
+          <div class="mt-3 text-xs text-slate-500">
+            <p>WebView2 is pre-installed on Windows 10/11.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Decky -->
+      <div class="bg-slate-900 border border-slate-800 rounded-2xl p-6">
+        <h4 class="font-semibold text-purple-400 mb-3 flex items-center gap-2">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/></svg>
+          Decky Plugin
+        </h4>
+        <div class="text-sm text-slate-400 space-y-2">
+          <p>1. Download <code class="text-capy-400">CapyDeploy-vX.Y.Z.zip</code></p>
+          <p>2. On your handheld, open <strong class="text-slate-300">Decky Settings</strong></p>
+          <p>3. Select <strong class="text-slate-300">Install Plugin from ZIP</strong></p>
+          <div class="mt-3 bg-slate-950 rounded-lg p-3">
+            <h5 class="text-xs font-semibold text-purple-400 mb-2">Agent vs Decky Plugin</h5>
+            <div class="text-xs text-slate-400 space-y-1">
+              <div class="flex justify-between"><span>Shortcuts</span><span class="text-slate-300">Instant (SteamClient API)</span></div>
+              <div class="flex justify-between"><span>Artwork</span><span class="text-slate-300">Instant (no file copy)</span></div>
+              <div class="flex justify-between"><span>Steam restart</span><span class="text-slate-300">Not needed</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Divider -->
+    <div class="relative mb-16">
+      <div class="absolute inset-0 flex items-center"><div class="w-full border-t border-slate-800"></div></div>
+      <div class="relative flex justify-center"><span class="bg-slate-950 px-4 text-sm text-slate-500">For contributors</span></div>
+    </div>
+
+    <!-- Build from Source -->
+    <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">Building from Source</h2>
+    <p class="text-slate-400 text-center mb-12">For contributors and developers who want to build from source code.</p>
 
     <div class="space-y-8">
       <!-- Step 1 -->
@@ -52,88 +184,6 @@ cd apps/agents/desktop && ./build.sh</code></pre>
 <span class="text-slate-500"># On PC</span>
 ./capydeploy-hub
 <span class="text-slate-500"># Enter the pairing code → Done!</span></code></pre>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- AppImage (Linux) -->
-    <div class="mt-12">
-      <h3 class="text-2xl font-bold mb-6">AppImage (Linux)</h3>
-      <p class="text-slate-400 mb-6">For easy distribution on Linux without dependencies.</p>
-
-      <div class="space-y-6">
-        <!-- Build AppImage -->
-        <div class="flex gap-6">
-          <div class="flex-shrink-0 w-12 h-12 rounded-full bg-green-600 flex items-center justify-center text-white font-bold">
-            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"></path></svg>
-          </div>
-          <div class="flex-1">
-            <h4 class="text-lg font-semibold mb-2">Build AppImage</h4>
-            <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-              <pre class="text-sm overflow-x-auto"><code class="text-slate-300"><span class="text-slate-500"># Build Hub (includes AppImage)</span>
-cd apps/hub && ./build.sh
-
-<span class="text-slate-500"># Build Agent (includes AppImage)</span>
-cd apps/agents/desktop && ./build.sh</code></pre>
-            </div>
-            <p class="text-slate-500 text-sm mt-2">Output: <code class="text-capy-400">dist/appimage/CapyDeploy_Hub.AppImage</code></p>
-          </div>
-        </div>
-
-        <!-- Auto-Install -->
-        <div class="flex gap-6">
-          <div class="flex-shrink-0 w-12 h-12 rounded-full bg-green-600 flex items-center justify-center text-white font-bold">
-            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path></svg>
-          </div>
-          <div class="flex-1">
-            <h4 class="text-lg font-semibold mb-2">Auto-Installation</h4>
-            <p class="text-slate-400 mb-3">Double-click the AppImage and it will prompt to install:</p>
-            <ul class="text-slate-400 text-sm space-y-1 mb-4">
-              <li>• Moves to <code class="text-capy-400">~/.local/bin/</code></li>
-              <li>• Creates desktop entry in <code class="text-capy-400">~/.local/share/applications/</code></li>
-              <li>• Copies icon to <code class="text-capy-400">~/.local/share/icons/</code></li>
-            </ul>
-            <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-              <pre class="text-sm overflow-x-auto"><code class="text-slate-300"><span class="text-slate-500"># Command line options</span>
-./CapyDeploy_Agent.AppImage --install    <span class="text-slate-500"># Install manually</span>
-./CapyDeploy_Agent.AppImage --uninstall  <span class="text-slate-500"># Remove</span>
-./CapyDeploy_Agent.AppImage --help       <span class="text-slate-500"># Show options</span></code></pre>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Decky Plugin (Gaming Mode) -->
-    <div class="mt-12">
-      <h3 class="text-2xl font-bold mb-6">Decky Plugin (Gaming Mode)</h3>
-      <p class="text-slate-400 mb-6">Alternative Agent that runs inside <a href="https://github.com/SteamDeckHomebrew/decky-loader" class="text-capy-400 hover:underline">Decky Loader</a> — no Steam restart needed.</p>
-
-      <div class="space-y-6">
-        <div class="flex gap-6">
-          <div class="flex-shrink-0 w-12 h-12 rounded-full bg-purple-600 flex items-center justify-center text-white font-bold">
-            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"></path></svg>
-          </div>
-          <div class="flex-1">
-            <h4 class="text-lg font-semibold mb-2">Build & Install</h4>
-            <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-              <pre class="text-sm overflow-x-auto"><code class="text-slate-300"><span class="text-slate-500"># Build (requires Node.js + Python 3)</span>
-cd apps/agents/decky && ./build.sh
-<span class="text-slate-500"># Output: dist/decky/CapyDeploy-vX.Y.Z.zip</span>
-
-<span class="text-slate-500"># Install on handheld:</span>
-<span class="text-slate-500"># Decky Settings > Install Plugin from ZIP</span></code></pre>
-            </div>
-            <div class="mt-4 bg-slate-900 border border-slate-800 rounded-xl p-4">
-              <h5 class="text-sm font-semibold text-capy-400 mb-2">Agent vs Decky Plugin</h5>
-              <div class="text-sm text-slate-400 space-y-1">
-                <div class="flex justify-between"><span>Shortcuts</span><span class="text-slate-300">Instant (SteamClient API)</span></div>
-                <div class="flex justify-between"><span>Artwork</span><span class="text-slate-300">Instant (no file copy)</span></div>
-                <div class="flex justify-between"><span>UI</span><span class="text-slate-300">Quick Access Menu panel</span></div>
-                <div class="flex justify-between"><span>Steam restart</span><span class="text-slate-300">Not needed</span></div>
-              </div>
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Reestructura `docs/install.html`: sección **Download** prominente al inicio con cards (Hub, Agent, Decky), botón de descarga a GitHub Releases, instrucciones por plataforma (Linux/Windows/Decky). "Build from Source" queda como sección secundaria para contribuidores.
- Actualiza hero CTAs en `docs/index.html`: botón primario "Download" → `/install`, secundario "Usage Guide" → `/usage`, terciario "How it Works" → `/architecture`.
- Agrega sección **Download** al `README.md` con tabla de componentes y links directos a releases. Renombra "Building" → "Building from Source (for contributors)".

## Context

Después del release v0.3.0, la página de instalación era 100% "build from source" — un usuario final veía "Install Go 1.24+" como primer paso y se iba. Los binarios pre-compilados (AppImages, ZIPs, Decky plugin) ya existen en GitHub Releases pero la documentación no los mencionaba.

## Test plan

- [ ] Verificar que `docs/install.html` muestra Download como primera sección
- [ ] Verificar que los links a GitHub Releases funcionan correctamente
- [ ] Verificar que "Build from Source" sigue existiendo con el contenido original
- [ ] Verificar que el hero de `index.html` tiene los 3 CTAs correctos
- [ ] Verificar que la sección Download del README renderiza bien en GitHub