### PR TITLE
fix(decky): leer versión desde package.json en vez de hardcodear

### DIFF
--- a/apps/agents/decky/main.py
+++ b/apps/agents/decky/main.py
@@ -3,6 +3,7 @@ CapyDeploy Decky Plugin - Backend
 Thin entry point: all logic lives in dedicated modules.
 """
 
+import json
 import os
 import sys
 import time
@@ -34,7 +35,17 @@ from upload import UploadSession
 from artwork import download_artwork, set_shortcut_icon, set_shortcut_icon_from_url
 from ws_server import WebSocketServer
 
-PLUGIN_VERSION = "0.1.0"
+def _read_version() -> str:
+    """Read version from package.json at plugin directory."""
+    try:
+        pkg_path = os.path.join(PLUGIN_DIR, "package.json")
+        with open(pkg_path, "r") as f:
+            return json.load(f).get("version", "0.0.0")
+    except Exception:
+        return "0.0.0"
+
+
+PLUGIN_VERSION = _read_version()
 
 
 class Plugin:


### PR DESCRIPTION
## Resumen

- `PLUGIN_VERSION` en `main.py` estaba hardcodeado a `"0.1.0"` y nunca se actualizaba
- Ahora lee la versión de `package.json` en runtime, que release-please ya mantiene sincronizado

## Cadena de versiones

```
release-please → package.json (bump automático) → main.py lee en runtime → versión correcta
```

## Cambios

- Reemplaza constante hardcodeada por función `_read_version()` que lee `package.json`
- Fallback a `"0.0.0"` si no puede leer el archivo (defensive)
- `build.sh` ya copia `package.json` al directorio del plugin

## Testing

- [ ] Verificar que el plugin muestra la versión correcta (0.3.0) en el StatusPanel
- [ ] Verificar que la versión se reporta correctamente en `get_info` al Hub

Closes #81