### PR TITLE
ci: renombrar assets del release para URLs estables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,6 @@ jobs:
 
       - name: Package plugin
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           cd apps/agents/decky
 
           PLUGIN_NAME="CapyDeploy"
@@ -303,13 +302,13 @@ jobs:
           if [ -d "assets" ]; then cp -r assets "$BUILD_DIR/"; fi
 
           cd /tmp/decky-build
-          zip -r "$GITHUB_WORKSPACE/CapyDeploy-v${VERSION}.zip" "$PLUGIN_NAME"
+          zip -r "$GITHUB_WORKSPACE/CapyDeploy-Decky.zip" "$PLUGIN_NAME"
 
       - name: Upload Decky plugin
         uses: actions/upload-artifact@v4
         with:
           name: decky-plugin
-          path: CapyDeploy-v*.zip
+          path: CapyDeploy-Decky.zip
 
   release:
     name: Create Release
@@ -320,10 +319,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get version
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -331,7 +326,6 @@ jobs:
 
       - name: Package release assets
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           mkdir -p release
 
           # Linux tar.gz
@@ -339,13 +333,13 @@ jobs:
           cp artifacts/hub-linux-amd64/capydeploy-hub staging/linux/
           cp artifacts/agent-linux-amd64/capydeploy-agent staging/linux/
           chmod +x staging/linux/*
-          tar -czf "release/capydeploy-${VERSION}-linux-amd64.tar.gz" -C staging/linux .
+          tar -czf "release/capydeploy-linux-amd64.tar.gz" -C staging/linux .
 
           # Windows zip
           mkdir -p staging/windows
           cp artifacts/hub-windows-amd64/capydeploy-hub.exe staging/windows/
           cp artifacts/agent-windows-amd64/capydeploy-agent.exe staging/windows/
-          cd staging/windows && zip -r "../../release/capydeploy-${VERSION}-windows-amd64.zip" . && cd ../..
+          cd staging/windows && zip -r "../../release/capydeploy-windows-amd64.zip" . && cd ../..
 
           # AppImages
           cp artifacts/appimages/CapyDeploy_Hub.AppImage release/
@@ -353,7 +347,7 @@ jobs:
           chmod +x release/*.AppImage
 
           # Decky plugin
-          cp artifacts/decky-plugin/CapyDeploy-v*.zip release/
+          cp artifacts/decky-plugin/CapyDeploy-Decky.zip release/
 
           # Checksums
           cd release
@@ -369,11 +363,11 @@ jobs:
 
             | File | Description |
             |------|-------------|
-            | `capydeploy-${{ steps.version.outputs.version }}-linux-amd64.tar.gz` | Linux binaries (Hub + Agent) |
-            | `capydeploy-${{ steps.version.outputs.version }}-windows-amd64.zip` | Windows binaries (Hub + Agent) |
+            | `capydeploy-linux-amd64.tar.gz` | Linux binaries (Hub + Agent) |
+            | `capydeploy-windows-amd64.zip` | Windows binaries (Hub + Agent) |
             | `CapyDeploy_Hub.AppImage` | Hub AppImage (auto-install support) |
             | `CapyDeploy_Agent.AppImage` | Agent AppImage (auto-install support) |
-            | `CapyDeploy-v${{ steps.version.outputs.version }}.zip` | Decky Loader plugin |
+            | `CapyDeploy-Decky.zip` | Decky Loader plugin |
             | `checksums-sha256.txt` | SHA-256 checksums for all files |
           files: release/*
           generate_release_notes: false

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Pre-built binaries are available for each release:
 
 | Component | Linux | Windows |
 |-----------|-------|---------|
-| **Hub** (your PC) | AppImage | ZIP |
-| **Agent** (handheld) | AppImage | ZIP |
-| **Decky Plugin** (gaming mode) | ZIP | — |
+| **Hub** (your PC) | [AppImage](https://github.com/lobinuxsoft/capydeploy/releases/latest/download/CapyDeploy_Hub.AppImage) | [ZIP](https://github.com/lobinuxsoft/capydeploy/releases/latest/download/capydeploy-windows-amd64.zip) |
+| **Agent** (handheld) | [AppImage](https://github.com/lobinuxsoft/capydeploy/releases/latest/download/CapyDeploy_Agent.AppImage) | [ZIP](https://github.com/lobinuxsoft/capydeploy/releases/latest/download/capydeploy-windows-amd64.zip) |
+| **Decky Plugin** (gaming mode) | [ZIP](https://github.com/lobinuxsoft/capydeploy/releases/latest/download/CapyDeploy-Decky.zip) | — |
 
-**[Download Latest Release](https://github.com/lobinuxsoft/capydeploy/releases/latest)** · [All releases](https://github.com/lobinuxsoft/capydeploy/releases)
+Also available: [Linux tar.gz](https://github.com/lobinuxsoft/capydeploy/releases/latest/download/capydeploy-linux-amd64.tar.gz) (Hub + Agent) · [Checksums](https://github.com/lobinuxsoft/capydeploy/releases/latest/download/checksums-sha256.txt) · [All releases](https://github.com/lobinuxsoft/capydeploy/releases)
 
 See the [Installation Guide](https://lobinuxsoft.github.io/capydeploy/install) for platform-specific instructions.
 
@@ -112,7 +112,7 @@ The Decky plugin is an alternative Agent for gaming mode. Requires [Decky Loader
 
 ```bash
 cd apps/agents/decky && ./build.sh
-# Output: dist/decky/CapyDeploy-vX.Y.Z.zip
+# Output: dist/decky/CapyDeploy-Decky.zip
 # Install via Decky Settings > Install from ZIP
 ```
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -19,10 +19,15 @@ title: Installation
         </div>
         <h3 class="text-lg font-semibold mb-2">Hub <span class="text-sm text-slate-500 font-normal">(Your PC)</span></h3>
         <p class="text-slate-400 text-sm mb-4 flex-1">Discovers agents, sends games, manages your library.</p>
-        <div class="space-y-2 text-sm">
-          <span class="block text-slate-500">Available as:</span>
-          <span class="inline-block px-2 py-1 rounded bg-green-500/10 text-green-400 text-xs">Linux AppImage</span>
-          <span class="inline-block px-2 py-1 rounded bg-blue-500/10 text-blue-400 text-xs">Windows ZIP</span>
+        <div class="flex flex-wrap gap-2">
+          <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/CapyDeploy_Hub.AppImage" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-green-500/10 text-green-400 text-xs font-medium hover:bg-green-500/20 transition">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+            Linux AppImage
+          </a>
+          <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/capydeploy-windows-amd64.zip" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-500/10 text-blue-400 text-xs font-medium hover:bg-blue-500/20 transition">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+            Windows ZIP
+          </a>
         </div>
       </div>
 
@@ -35,10 +40,15 @@ title: Installation
         </div>
         <h3 class="text-lg font-semibold mb-2">Agent <span class="text-sm text-slate-500 font-normal">(Handheld)</span></h3>
         <p class="text-slate-400 text-sm mb-4 flex-1">Receives games, creates Steam shortcuts, applies artwork.</p>
-        <div class="space-y-2 text-sm">
-          <span class="block text-slate-500">Available as:</span>
-          <span class="inline-block px-2 py-1 rounded bg-green-500/10 text-green-400 text-xs">Linux AppImage</span>
-          <span class="inline-block px-2 py-1 rounded bg-blue-500/10 text-blue-400 text-xs">Windows ZIP</span>
+        <div class="flex flex-wrap gap-2">
+          <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/CapyDeploy_Agent.AppImage" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-green-500/10 text-green-400 text-xs font-medium hover:bg-green-500/20 transition">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+            Linux AppImage
+          </a>
+          <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/capydeploy-windows-amd64.zip" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-500/10 text-blue-400 text-xs font-medium hover:bg-blue-500/20 transition">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+            Windows ZIP
+          </a>
         </div>
       </div>
 
@@ -51,20 +61,28 @@ title: Installation
         </div>
         <h3 class="text-lg font-semibold mb-2">Decky Plugin <span class="text-sm text-slate-500 font-normal">(Gaming Mode)</span></h3>
         <p class="text-slate-400 text-sm mb-4 flex-1">Alternative Agent inside <a href="https://github.com/SteamDeckHomebrew/decky-loader" class="text-purple-400 hover:underline">Decky Loader</a>. No Steam restart needed.</p>
-        <div class="space-y-2 text-sm">
-          <span class="block text-slate-500">Available as:</span>
-          <span class="inline-block px-2 py-1 rounded bg-purple-500/10 text-purple-400 text-xs">ZIP (Decky plugin)</span>
+        <div class="flex flex-wrap gap-2">
+          <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/CapyDeploy-Decky.zip" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-purple-500/10 text-purple-400 text-xs font-medium hover:bg-purple-500/20 transition">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+            Decky Plugin ZIP
+          </a>
         </div>
       </div>
     </div>
 
-    <!-- Download Button -->
+    <!-- Extra Downloads -->
     <div class="text-center mb-16">
-      <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest" class="inline-flex items-center gap-2 px-8 py-4 rounded-xl bg-gradient-to-r from-capy-500 to-capy-600 text-white font-semibold hover:from-capy-600 hover:to-capy-700 transition shadow-lg shadow-capy-500/25">
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
-        Download Latest Release
-      </a>
-      <p class="text-slate-500 text-sm mt-3">
+      <div class="flex flex-wrap justify-center gap-3 mb-4">
+        <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/capydeploy-linux-amd64.tar.gz" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-slate-800 border border-slate-700 text-slate-300 text-sm font-medium hover:bg-slate-700 transition">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+          Linux tar.gz (Hub + Agent)
+        </a>
+        <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/checksums-sha256.txt" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-slate-800 border border-slate-700 text-slate-300 text-sm font-medium hover:bg-slate-700 transition">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+          Checksums (SHA-256)
+        </a>
+      </div>
+      <p class="text-slate-500 text-sm">
         <a href="https://github.com/lobinuxsoft/capydeploy/releases" class="hover:text-slate-300 transition">Browse all releases &rarr;</a>
       </p>
     </div>
@@ -114,7 +132,7 @@ title: Installation
           Decky Plugin
         </h4>
         <div class="text-sm text-slate-400 space-y-2">
-          <p>1. Download <code class="text-capy-400">CapyDeploy-vX.Y.Z.zip</code></p>
+          <p>1. Download <code class="text-capy-400">CapyDeploy-Decky.zip</code> from the card above</p>
           <p>2. On your handheld, open <strong class="text-slate-300">Decky Settings</strong></p>
           <p>3. Select <strong class="text-slate-300">Install Plugin from ZIP</strong></p>
           <div class="mt-3 bg-slate-950 rounded-lg p-3">


### PR DESCRIPTION
## Summary
- Elimina la versión de los nombres de assets del release (`capydeploy-linux-amd64.tar.gz`, `capydeploy-windows-amd64.zip`, `CapyDeploy-Decky.zip`) para permitir URLs estables con `releases/latest/download/`
- Actualiza `docs/install.html` con botones de descarga directa por componente en cada card (Hub, Agent, Decky)
- Actualiza `README.md` con tabla de links directos a cada asset

## Asset names: before → after

| Before | After |
|--------|-------|
| `capydeploy-X.Y.Z-linux-amd64.tar.gz` | `capydeploy-linux-amd64.tar.gz` |
| `capydeploy-X.Y.Z-windows-amd64.zip` | `capydeploy-windows-amd64.zip` |
| `CapyDeploy-vX.Y.Z.zip` | `CapyDeploy-Decky.zip` |
| `CapyDeploy_Hub.AppImage` | (sin cambio) |
| `CapyDeploy_Agent.AppImage` | (sin cambio) |

## Test plan
- [ ] Verificar que `release.yml` no contiene `${VERSION}` en nombres de assets
- [ ] Verificar que la tabla del body del release usa nombres fijos
- [ ] Verificar links directos en `docs/install.html` apuntan a `releases/latest/download/`
- [ ] Verificar links directos en `README.md`
- [ ] Ejecutar un release de prueba (o validar YAML syntax)

Closes #85