### PR TITLE
fix(decky): mostrar juegos instalados sin conexión activa

### DIFF
--- a/apps/agents/decky/src/components/InstalledGames.tsx
+++ b/apps/agents/decky/src/components/InstalledGames.tsx
@@ -32,12 +32,11 @@ interface InstalledGame {
 }
 
 interface InstalledGamesProps {
-  enabled: boolean;
   installPath: string;
   refreshTrigger?: number;
 }
 
-const InstalledGames: VFC<InstalledGamesProps> = ({ enabled, installPath, refreshTrigger }) => {
+const InstalledGames: VFC<InstalledGamesProps> = ({ installPath, refreshTrigger }) => {
   const [games, setGames] = useState<InstalledGame[]>([]);
   const [loading, setLoading] = useState(true);
   const [uninstalling, setUninstalling] = useState<string | null>(null);
@@ -55,10 +54,8 @@ const InstalledGames: VFC<InstalledGamesProps> = ({ enabled, installPath, refres
   }, []);
 
   useEffect(() => {
-    if (enabled) {
-      loadGames();
-    }
-  }, [enabled, loadGames, installPath, refreshTrigger]);
+    loadGames();
+  }, [loadGames, installPath, refreshTrigger]);
 
   const formatSize = (bytes: number): string => {
     if (bytes < 1024) return `${bytes} B`;
@@ -103,8 +100,6 @@ const InstalledGames: VFC<InstalledGamesProps> = ({ enabled, installPath, refres
       />
     );
   };
-
-  if (!enabled) return null;
 
   return (
     <div className="cd-section">

--- a/apps/agents/decky/src/index.tsx
+++ b/apps/agents/decky/src/index.tsx
@@ -95,7 +95,7 @@ const CapyDeployPanel: VFC = () => {
 
       <AuthorizedHubs enabled={enabled} />
 
-      <InstalledGames enabled={enabled} installPath={status?.installPath ?? ""} refreshTrigger={gamesRefresh} />
+      <InstalledGames installPath={status?.installPath ?? ""} refreshTrigger={gamesRefresh} />
 
       <ProgressPanel operation={currentOperation} uploadProgress={uploadProgress} />
     </div>


### PR DESCRIPTION
## Resumen
- Elimina la dependencia de `enabled` en `InstalledGames` para que la sección sea visible y funcional independientemente del estado del servidor WebSocket
- Las operaciones `get_installed_games` y `uninstall_game` usan IPC local de Decky (`call()`), no requieren conexión activa

## Cambios
- `InstalledGames.tsx`: elimina prop `enabled`, guard `if (!enabled) return null` y condición en `useEffect`
- `index.tsx`: elimina prop `enabled={enabled}` del componente `<InstalledGames>`

## Testing
- [x] Build exitoso (`npm run build`)
- [x] Toggle ON + Hub conectado → se ven juegos instalados
- [x] Toggle ON + Hub desconectado → se ven juegos instalados
- [x] Toggle OFF → se ven juegos instalados (NUEVO)
- [x] Desinstalar juego con toggle OFF → funciona (NUEVO)

Closes #82