### PR TITLE
refactor: eliminar campo capabilities redundante del protocolo

### DIFF
--- a/apps/agents/decky/src/components/StatusPanel.tsx
+++ b/apps/agents/decky/src/components/StatusPanel.tsx
@@ -69,8 +69,6 @@ const StatusPanel: VFC<StatusPanelProps> = ({
   const [statusExpanded, toggleStatus] = usePanelState("status");
   const [infoExpanded, toggleInfo] = usePanelState("info");
   const [networkExpanded, toggleNetwork] = usePanelState("network");
-  const [capabilitiesExpanded, toggleCapabilities] = usePanelState("capabilities");
-
   const handleEditName = () => {
     showModal(<NameEditModal currentName={agentName} onSaved={onRefresh} />);
   };
@@ -242,31 +240,6 @@ const StatusPanel: VFC<StatusPanelProps> = ({
         </div>
       )}
 
-      <div className="cd-section">
-        <div className="cd-section-title" onClick={toggleCapabilities}>
-          {capabilitiesExpanded ? <FaChevronDown size={10} color={colors.primary} /> : <FaChevronRight size={10} color={colors.disabled} />}
-          Capabilities
-        </div>
-        {capabilitiesExpanded && (
-          <PanelSection>
-            <PanelSectionRow>
-              <Field label="File upload">
-                <span className="cd-text-primary">Yes</span>
-              </Field>
-            </PanelSectionRow>
-            <PanelSectionRow>
-              <Field label="Steam Shortcuts">
-                <span className="cd-text-primary">Yes</span>
-              </Field>
-            </PanelSectionRow>
-            <PanelSectionRow>
-              <Field label="Steam Artwork">
-                <span className="cd-text-primary">Yes</span>
-              </Field>
-            </PanelSectionRow>
-          </PanelSection>
-        )}
-      </div>
     </>
   );
 };

--- a/apps/agents/decky/ws_server.py
+++ b/apps/agents/decky/ws_server.py
@@ -257,7 +257,6 @@ class WebSocketServer:
                 "platform": "linux",
                 "version": self.plugin.version,
                 "acceptConnections": self.plugin.accept_connections,
-                "capabilities": ["file_upload", "steam_shortcuts", "steam_artwork"],
             }
         })
 

--- a/apps/agents/desktop/app.go
+++ b/apps/agents/desktop/app.go
@@ -611,25 +611,6 @@ func (a *App) GetVersion() version.Info {
 	return version.GetInfo()
 }
 
-// CapabilityInfo represents a capability for the frontend.
-type CapabilityInfo struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
-
-// GetCapabilities returns the list of agent capabilities.
-func (a *App) GetCapabilities() []CapabilityInfo {
-	return []CapabilityInfo{
-		{ID: "file_upload", Name: "Transferencia de archivos", Description: "Recibir juegos desde el Hub"},
-		{ID: "file_list", Name: "Listar archivos", Description: "Ver archivos en el directorio de instalación"},
-		{ID: "steam_shortcuts", Name: "Shortcuts de Steam", Description: "Crear y eliminar accesos directos en Steam"}, //nolint:misspell // "directos" is Spanish
-		{ID: "steam_artwork", Name: "Artwork de Steam", Description: "Configurar imágenes de portada, hero, logo e icono"},
-		{ID: "steam_users", Name: "Usuarios de Steam", Description: "Listar usuarios de Steam locales"},
-		{ID: "steam_restart", Name: "Reiniciar Steam", Description: "Reiniciar Steam para aplicar cambios"},
-	}
-}
-
 // =============================================================================
 // Helper functions
 // =============================================================================

--- a/apps/agents/desktop/frontend/src/lib/components/StatusPanel.svelte
+++ b/apps/agents/desktop/frontend/src/lib/components/StatusPanel.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
 	import { Card, Badge, Button, Input } from '$lib/components/ui';
-	import { GetStatus, GetVersion, GetCapabilities, SetAcceptConnections, DisconnectHub, SetName, GetInstallPath, SelectInstallPath, EventsOn, EventsOff } from '$lib/wailsjs';
-	import type { AgentStatus, VersionInfo, CapabilityInfo } from '$lib/types';
-	import { Monitor, Wifi, WifiOff, Unplug, Pencil, Check, X, Folder, FolderOpen, Key, Info, Zap, ChevronDown, ChevronRight } from 'lucide-svelte';
+	import { GetStatus, GetVersion, SetAcceptConnections, DisconnectHub, SetName, GetInstallPath, SelectInstallPath, EventsOn, EventsOff } from '$lib/wailsjs';
+	import type { AgentStatus, VersionInfo } from '$lib/types';
+	import { Monitor, Wifi, WifiOff, Unplug, Pencil, Check, X, Folder, FolderOpen, Key, Info, ChevronDown, ChevronRight } from 'lucide-svelte';
 
 	let status = $state<AgentStatus | null>(null);
 	let versionInfo = $state<VersionInfo | null>(null);
-	let capabilities = $state<CapabilityInfo[]>([]);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let editingName = $state(false);
@@ -18,7 +17,7 @@
 	let pairingTimer: ReturnType<typeof setTimeout> | null = null;
 
 	// Collapsible sections state
-	let expandedSections = $state<Set<string>>(new Set(['version', 'install', 'network', 'capabilities', 'connections']));
+	let expandedSections = $state<Set<string>>(new Set(['version', 'install', 'network', 'connections']));
 
 	function toggleSection(section: string) {
 		if (expandedSections.has(section)) {
@@ -34,7 +33,6 @@
 			status = await GetStatus();
 			installPath = await GetInstallPath();
 			versionInfo = await GetVersion();
-			capabilities = await GetCapabilities();
 			error = null;
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Error loading status';
@@ -315,38 +313,6 @@
 				</div>
 			{/if}
 		</div>
-
-		<!-- Capabilities -->
-		{#if capabilities.length > 0}
-			<div class="cd-section p-4">
-				<button
-					type="button"
-					class="w-full flex items-center gap-2 hover:text-primary transition-colors"
-					onclick={() => toggleSection('capabilities')}
-				>
-					{#if expandedSections.has('capabilities')}
-						<ChevronDown class="w-4 h-4 cd-text-primary" />
-					{:else}
-						<ChevronRight class="w-4 h-4 cd-text-disabled" />
-					{/if}
-					<Zap class="w-4 h-4 cd-text-primary" />
-					<span class="cd-section-title">Capabilities</span>
-				</button>
-				{#if expandedSections.has('capabilities')}
-					<div class="pl-6 space-y-2 mt-3">
-						{#each capabilities as cap}
-							<div class="flex items-start gap-2">
-								<span class="cd-pulse mt-1" style="width: 6px; height: 6px;"></span>
-								<div>
-									<span class="text-sm font-medium">{cap.name}</span>
-									<p class="text-xs cd-text-disabled">{cap.description}</p>
-								</div>
-							</div>
-						{/each}
-					</div>
-				{/if}
-			</div>
-		{/if}
 
 		<!-- Pairing Code (shown when a Hub requests pairing) -->
 		{#if pairingCode}

--- a/apps/agents/desktop/frontend/src/lib/types.ts
+++ b/apps/agents/desktop/frontend/src/lib/types.ts
@@ -32,8 +32,3 @@ export interface ShortcutInfo {
 	startDir: string;
 }
 
-export interface CapabilityInfo {
-	id: string;
-	name: string;
-	description: string;
-}

--- a/apps/agents/desktop/frontend/src/lib/wailsjs.ts
+++ b/apps/agents/desktop/frontend/src/lib/wailsjs.ts
@@ -15,7 +15,6 @@ export const SetInstallPath = App.SetInstallPath;
 export const SelectInstallPath = App.SelectInstallPath;
 export const GetAuthorizedHubs = App.GetAuthorizedHubs;
 export const RevokeHub = App.RevokeHub;
-export const GetCapabilities = App.GetCapabilities;
 
 // Runtime
 export const EventsOn = runtime.EventsOn;

--- a/apps/agents/desktop/frontend/wailsjs/go/main/App.d.ts
+++ b/apps/agents/desktop/frontend/wailsjs/go/main/App.d.ts
@@ -8,8 +8,6 @@ export function DisconnectHub():Promise<void>;
 
 export function GetAuthorizedHubs():Promise<Array<main.AuthorizedHubInfo>>;
 
-export function GetCapabilities():Promise<Array<main.CapabilityInfo>>;
-
 export function GetInstallPath():Promise<string>;
 
 export function GetShortcuts(arg1:string):Promise<Array<main.ShortcutInfo>>;

--- a/apps/agents/desktop/frontend/wailsjs/go/main/App.js
+++ b/apps/agents/desktop/frontend/wailsjs/go/main/App.js
@@ -14,10 +14,6 @@ export function GetAuthorizedHubs() {
   return window['go']['main']['App']['GetAuthorizedHubs']();
 }
 
-export function GetCapabilities() {
-  return window['go']['main']['App']['GetCapabilities']();
-}
-
 export function GetInstallPath() {
   return window['go']['main']['App']['GetInstallPath']();
 }

--- a/apps/agents/desktop/frontend/wailsjs/go/models.ts
+++ b/apps/agents/desktop/frontend/wailsjs/go/models.ts
@@ -78,23 +78,6 @@ export namespace main {
 	        this.lastSeen = source["lastSeen"];
 	    }
 	}
-	export class CapabilityInfo {
-	    id: string;
-	    name: string;
-	    description: string;
-	
-	    static createFrom(source: any = {}) {
-	        return new CapabilityInfo(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.id = source["id"];
-	        this.name = source["name"];
-	        this.description = source["description"];
-	    }
-	}
-	
 	export class ShortcutInfo {
 	    appId: number;
 	    name: string;

--- a/apps/agents/desktop/server/server.go
+++ b/apps/agents/desktop/server/server.go
@@ -223,16 +223,6 @@ func (s *Server) GetInfo() protocol.AgentInfo {
 		supportedFormats = []string{"image/png", "image/jpeg", "image/webp", "image/gif"}
 	}
 
-	// PC Agent with Steam supports all capabilities.
-	capabilities := []protocol.Capability{
-		protocol.CapFileUpload,
-		protocol.CapFileList,
-		protocol.CapSteamShortcuts,
-		protocol.CapSteamArtwork,
-		protocol.CapSteamUsers,
-		protocol.CapSteamRestart,
-	}
-
 	return protocol.AgentInfo{
 		ID:                    s.id,
 		Name:                  s.cfg.Name,
@@ -240,7 +230,6 @@ func (s *Server) GetInfo() protocol.AgentInfo {
 		Version:               s.cfg.Version,
 		AcceptConnections:     acceptConnections,
 		SupportedImageFormats: supportedFormats,
-		Capabilities:          capabilities,
 	}
 }
 

--- a/apps/agents/desktop/server/server_test.go
+++ b/apps/agents/desktop/server/server_test.go
@@ -69,9 +69,6 @@ func TestGetInfo(t *testing.T) {
 	if !info.AcceptConnections {
 		t.Error("info.AcceptConnections = false, want true (default)")
 	}
-	if len(info.Capabilities) == 0 {
-		t.Error("info.Capabilities is empty")
-	}
 	if len(info.SupportedImageFormats) == 0 {
 		t.Error("info.SupportedImageFormats is empty")
 	}

--- a/apps/hub/app.go
+++ b/apps/hub/app.go
@@ -31,7 +31,7 @@ type ConnectedAgent struct {
 	Agent    *discovery.DiscoveredAgent
 	Client   modules.PlatformClient  // Interface for capability checks (type assertions)
 	WSClient *modules.WSClient       // WebSocket client for WS-specific operations
-	Info     *protocol.AgentInfo     // Full agent info from WS connection (includes capabilities)
+	Info     *protocol.AgentInfo     // Full agent info from WS connection
 }
 
 // ConnectionStatus represents the current connection status
@@ -44,7 +44,6 @@ type ConnectionStatus struct {
 	Port                  int      `json:"port"`
 	IPs                   []string `json:"ips"`
 	SupportedImageFormats []string `json:"supportedImageFormats"`
-	Capabilities          []string `json:"capabilities"`
 }
 
 // DiscoveredAgentInfo represents agent info for the frontend

--- a/apps/hub/app_connection.go
+++ b/apps/hub/app_connection.go
@@ -210,15 +210,6 @@ func (a *App) GetConnectionStatus() ConnectionStatus {
 		ips = append(ips, ip.String())
 	}
 
-	// Convert capabilities to strings for JSON serialization
-	var capabilities []string
-	if info != nil {
-		capabilities = make([]string, len(info.Capabilities))
-		for i, cap := range info.Capabilities {
-			capabilities[i] = string(cap)
-		}
-	}
-
 	// Use formats from agent info if available, otherwise fall back to platform-based
 	var supportedFormats []string
 	if info != nil && len(info.SupportedImageFormats) > 0 {
@@ -236,7 +227,6 @@ func (a *App) GetConnectionStatus() ConnectionStatus {
 		Port:                  agent.Port,
 		IPs:                   ips,
 		SupportedImageFormats: supportedFormats,
-		Capabilities:          capabilities,
 	}
 }
 

--- a/apps/hub/frontend/wailsjs/go/models.ts
+++ b/apps/hub/frontend/wailsjs/go/models.ts
@@ -68,12 +68,11 @@ export namespace main {
 	    port: number;
 	    ips: string[];
 	    supportedImageFormats: string[];
-	    capabilities: string[];
-	
+
 	    static createFrom(source: any = {}) {
 	        return new ConnectionStatus(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.connected = source["connected"];
@@ -84,7 +83,6 @@ export namespace main {
 	        this.port = source["port"];
 	        this.ips = source["ips"];
 	        this.supportedImageFormats = source["supportedImageFormats"];
-	        this.capabilities = source["capabilities"];
 	    }
 	}
 	export class DiscoveredAgentInfo {

--- a/pkg/protocol/types.go
+++ b/pkg/protocol/types.go
@@ -3,45 +3,14 @@ package protocol
 
 import "time"
 
-// Capability represents a feature supported by an agent.
-// Capabilities are used by the Hub to dynamically show/hide UI sections
-// based on what the connected Agent supports.
-type Capability string
-
-// Available capabilities that an agent can report.
-//
-// File capabilities:
-//   - CapFileUpload: Agent can receive game file uploads from the Hub
-//   - CapFileList: Agent can list installed games/files
-//
-// Steam capabilities (require Steam client on agent machine):
-//   - CapSteamShortcuts: Agent can create/delete Steam non-Steam game shortcuts
-//   - CapSteamArtwork: Agent can apply custom artwork to shortcuts
-//   - CapSteamUsers: Agent can list local Steam users
-//   - CapSteamRestart: Agent can restart the Steam client
-//
-// Platform support:
-//   - PC (Windows/Linux/macOS) with Steam: all capabilities
-//   - PC without Steam: file_upload, file_list only
-//   - Android (future): file_upload, file_list only
-const (
-	CapFileUpload     Capability = "file_upload"
-	CapFileList       Capability = "file_list"
-	CapSteamShortcuts Capability = "steam_shortcuts"
-	CapSteamArtwork   Capability = "steam_artwork"
-	CapSteamUsers     Capability = "steam_users"
-	CapSteamRestart   Capability = "steam_restart"
-)
-
 // AgentInfo contains information about a discovered agent.
 type AgentInfo struct {
-	ID                    string       `json:"id"`
-	Name                  string       `json:"name"`
-	Platform              string       `json:"platform"`
-	Version               string       `json:"version"`
-	AcceptConnections     bool         `json:"acceptConnections"`
-	SupportedImageFormats []string     `json:"supportedImageFormats"`
-	Capabilities          []Capability `json:"capabilities"`
+	ID                    string   `json:"id"`
+	Name                  string   `json:"name"`
+	Platform              string   `json:"platform"`
+	Version               string   `json:"version"`
+	AcceptConnections     bool     `json:"acceptConnections"`
+	SupportedImageFormats []string `json:"supportedImageFormats"`
 }
 
 // UploadConfig defines the configuration for uploading a game.


### PR DESCRIPTION
## Resumen

Elimina el sistema declarativo de capabilities del protocolo. Existían dos sistemas paralelos:
1. **Type assertions del Hub** (`modules/assertions.go`) — detecta capacidades via interfaces Go. **Sistema real, intacto.**
2. **Array de strings en el protocolo** (`AgentInfo.Capabilities`) — cada agente declaraba manualmente sus capabilities. **Nadie lo consultaba.**

## Cambios

- **`pkg/protocol/types.go`**: eliminado tipo `Capability`, 6 constantes `Cap*`, campo `Capabilities` de `AgentInfo`
- **Agent Desktop (Go)**: eliminado array capabilities en `server.go`, assertion en test, struct `CapabilityInfo` y `GetCapabilities()` en `app.go`
- **Agent Desktop (frontend)**: eliminada sección Capabilities del `StatusPanel.svelte`, interface `CapabilityInfo`, export `GetCapabilities`, archivos autogenerados Wails
- **Decky**: eliminada línea `capabilities` en `ws_server.py`, sección Capabilities en `StatusPanel.tsx`
- **Hub**: eliminado campo `Capabilities` de `ConnectionStatus`, bloque de conversión en `app_connection.go`, modelo autogenerado

### No se toca
- `apps/hub/modules/assertions.go` — `ClientCapabilities` + `GetCapabilities()` (sistema real)
- `apps/hub/modules/modules_test.go` — tests del sistema real

## Testing
- [x] `go test ./apps/agents/desktop/server/...` — pasa
- [x] `go vet ./apps/agents/desktop/...` — sin errores
- [x] `go vet ./apps/hub/...` — sin errores
- [x] `go vet ./pkg/...` — sin errores
- [x] `npm run build` (Decky) — compila ok
- [x] Sin referencias huérfanas a `Capability`/`capabilities` fuera de modules/

Closes #83