### PR TITLE
docs: reorganize download section by platform

### DIFF
--- a/docs/install.html
+++ b/docs/install.html
@@ -8,22 +8,16 @@ title: Installation
     <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">Download</h2>
     <p class="text-slate-400 text-center mb-12">Pre-built binaries ready to use. No compilation required.</p>
 
-    <!-- Download Cards -->
+    <!-- Download Cards by Platform -->
     <div class="grid md:grid-cols-3 gap-6 mb-12">
-      <!-- Hub -->
-      <div class="bg-slate-900/50 border border-capy-500/20 rounded-2xl p-6 flex flex-col">
-        <div class="w-12 h-12 rounded-xl bg-capy-500/10 flex items-center justify-center mb-4">
-          <svg class="w-6 h-6 text-capy-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
-          </svg>
+      <!-- Windows -->
+      <div class="bg-slate-900/50 border border-blue-500/20 rounded-2xl p-6 flex flex-col">
+        <div class="w-12 h-12 rounded-xl bg-blue-500/10 flex items-center justify-center mb-4">
+          <svg class="w-6 h-6 text-blue-400" fill="currentColor" viewBox="0 0 24 24"><path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/></svg>
         </div>
-        <h3 class="text-lg font-semibold mb-2">Hub <span class="text-sm text-slate-500 font-normal">(Your PC)</span></h3>
-        <p class="text-slate-400 text-sm mb-4 flex-1">Discovers agents, sends games, manages your library.</p>
+        <h3 class="text-lg font-semibold mb-2">Windows</h3>
+        <p class="text-slate-400 text-sm mb-4 flex-1">Hub + Agent bundled in a single ZIP. Extract and run.</p>
         <div class="flex flex-wrap gap-2">
-          <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/CapyDeploy_Hub.AppImage" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-green-500/10 text-green-400 text-xs font-medium hover:bg-green-500/20 transition">
-            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
-            Linux AppImage
-          </a>
           <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/capydeploy-windows-amd64.zip" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-500/10 text-blue-400 text-xs font-medium hover:bg-blue-500/20 transition">
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
             Windows ZIP
@@ -31,23 +25,21 @@ title: Installation
         </div>
       </div>
 
-      <!-- Agent -->
-      <div class="bg-slate-900/50 border border-water-500/20 rounded-2xl p-6 flex flex-col">
-        <div class="w-12 h-12 rounded-xl bg-water-500/10 flex items-center justify-center mb-4">
-          <svg class="w-6 h-6 text-water-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>
-          </svg>
+      <!-- Linux -->
+      <div class="bg-slate-900/50 border border-green-500/20 rounded-2xl p-6 flex flex-col">
+        <div class="w-12 h-12 rounded-xl bg-green-500/10 flex items-center justify-center mb-4">
+          <svg class="w-6 h-6 text-green-400" fill="currentColor" viewBox="0 0 24 24"><path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.368 1.884 1.43.585.047 1.042-.245 1.484-.93.4-.644.752-1.474.939-2.386.029-.143.057-.26.127-.397.063-.119.185-.277.316-.333.349-.153.561-.347.672-.628.117-.282.127-.627.049-1.084-.058-.328-.63-1.256-.12-1.593.488-.31 1.44-1.147 1.852-2.238.191-.555.203-1.16.042-1.775-.162-.607-.543-1.233-.959-1.7-.816-.936-1.658-1.244-2.123-1.79-.455-.533-.636-1.15-.702-1.75-.065-.572.004-1.134-.074-1.7C17.1 1.894 14.897.003 12.504 0z"/></svg>
         </div>
-        <h3 class="text-lg font-semibold mb-2">Agent <span class="text-sm text-slate-500 font-normal">(Handheld)</span></h3>
-        <p class="text-slate-400 text-sm mb-4 flex-1">Receives games, creates Steam shortcuts, applies artwork.</p>
+        <h3 class="text-lg font-semibold mb-2">Linux</h3>
+        <p class="text-slate-400 text-sm mb-4 flex-1">AppImages with auto-install support. One for each component.</p>
         <div class="flex flex-wrap gap-2">
+          <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/CapyDeploy_Hub.AppImage" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-green-500/10 text-green-400 text-xs font-medium hover:bg-green-500/20 transition">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+            Hub AppImage
+          </a>
           <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/CapyDeploy_Agent.AppImage" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-green-500/10 text-green-400 text-xs font-medium hover:bg-green-500/20 transition">
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
-            Linux AppImage
-          </a>
-          <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/capydeploy-windows-amd64.zip" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-500/10 text-blue-400 text-xs font-medium hover:bg-blue-500/20 transition">
-            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
-            Windows ZIP
+            Agent AppImage
           </a>
         </div>
       </div>


### PR DESCRIPTION
Sync docs fix — download cards grouped by platform instead of by component.