### PR TITLE
fix(hub): show agent's install path instead of local Hub path

### DIFF
--- a/apps/hub-tauri/frontend/src/lib/wailsjs.ts
+++ b/apps/hub-tauri/frontend/src/lib/wailsjs.ts
@@ -35,7 +35,7 @@ export const RefreshDiscovery = () => invoke<DiscoveredAgent[]>('refresh_discove
 export const ConnectAgent = (agentID: string) => invoke<string>('connect_agent', { agentId: agentID });
 export const DisconnectAgent = () => invoke<void>('disconnect_agent');
 export const GetConnectionStatus = () => invoke<ConnectionStatus>('get_connection_status');
-export const GetAgentInstallPath = () => invoke<string>('get_game_log_directory');
+export const GetAgentInstallPath = () => invoke<string>('get_agent_install_path');
 
 // ---------------------------------------------------------------------------
 // Console log commands

--- a/apps/hub-tauri/src-tauri/src/commands/games.rs
+++ b/apps/hub-tauri/src-tauri/src/commands/games.rs
@@ -2,6 +2,9 @@
 
 use tauri::State;
 
+use capydeploy_protocol::constants::MessageType;
+use capydeploy_protocol::messages::ConfigResponse;
+
 use crate::agent_adapter::GamesAdapter;
 use crate::state::HubState;
 use crate::types::InstalledGameDto;
@@ -95,6 +98,22 @@ pub async fn update_game_artwork(
         .update_game_artwork(&adapter, app_id, &artwork)
         .await
         .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_agent_install_path(state: State<'_, HubState>) -> Result<String, String> {
+    let mgr = state.connection_mgr.clone();
+    let resp = mgr
+        .send_request::<()>(MessageType::GetConfig, None)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let config: ConfigResponse = resp
+        .parse_payload::<ConfigResponse>()
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "empty config response".to_string())?;
+
+    Ok(config.install_path)
 }
 
 #[tauri::command]

--- a/apps/hub-tauri/src-tauri/src/lib.rs
+++ b/apps/hub-tauri/src-tauri/src/lib.rs
@@ -100,6 +100,7 @@ pub fn run() {
             commands::games::delete_game,
             commands::games::update_game_artwork,
             commands::games::set_game_log_wrapper,
+            commands::games::get_agent_install_path,
             // SteamGridDB
             commands::steamgriddb::search_games,
             commands::steamgriddb::get_grids,


### PR DESCRIPTION
## Summary

- Fix: "Installed Games" tab showed the Hub's local path instead of the connected agent's install path
- New `get_agent_install_path` command sends `GetConfig` to the agent via WebSocket

## Test plan

- [x] CI passed on PR #162
- [ ] Connect Hub to agent, verify correct remote path displayed