### PR TITLE
fix: sync app versions with release-please VERSION file

### DIFF
--- a/apps/agents/agent-tauri/src-tauri/build.rs
+++ b/apps/agents/agent-tauri/src-tauri/build.rs
@@ -1,3 +1,21 @@
 fn main() {
+    // Read project version from workspace VERSION file
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let version_path = std::path::Path::new(&manifest_dir)
+        .ancestors()
+        .find_map(|p| {
+            let candidate = p.join("VERSION");
+            candidate.exists().then_some(candidate)
+        })
+        .expect("Could not find VERSION file in parent directories");
+
+    let version = std::fs::read_to_string(&version_path)
+        .expect("Failed to read VERSION file")
+        .trim()
+        .to_string();
+
+    println!("cargo:rustc-env=CAPYDEPLOY_VERSION={version}");
+    println!("cargo:rerun-if-changed={}", version_path.display());
+
     tauri_build::build()
 }

--- a/apps/agents/agent-tauri/src-tauri/src/commands/mod.rs
+++ b/apps/agents/agent-tauri/src-tauri/src/commands/mod.rs
@@ -48,7 +48,7 @@ pub async fn emit_status(app: &AppHandle, state: &Arc<AgentState>) {
         running: true,
         name: config.name.clone(),
         platform: std::env::consts::OS.into(),
-        version: env!("CARGO_PKG_VERSION").into(),
+        version: env!("CAPYDEPLOY_VERSION").into(),
         port,
         ips,
         accept_connections: state.accept_connections.load(Ordering::Relaxed),

--- a/apps/agents/agent-tauri/src-tauri/src/commands/status.rs
+++ b/apps/agents/agent-tauri/src-tauri/src/commands/status.rs
@@ -35,7 +35,7 @@ pub async fn get_status(state: State<'_, Arc<AgentState>>) -> Result<AgentStatus
         running: true,
         name: config.name.clone(),
         platform: std::env::consts::OS.into(),
-        version: env!("CARGO_PKG_VERSION").into(),
+        version: env!("CAPYDEPLOY_VERSION").into(),
         port,
         ips,
         accept_connections: state.accept_connections.load(Ordering::Relaxed),
@@ -53,7 +53,7 @@ pub async fn get_status(state: State<'_, Arc<AgentState>>) -> Result<AgentStatus
 #[tauri::command]
 pub async fn get_version() -> Result<VersionInfoDto, String> {
     Ok(VersionInfoDto {
-        version: env!("CARGO_PKG_VERSION").into(),
+        version: env!("CAPYDEPLOY_VERSION").into(),
         commit: String::new(),
         build_date: String::new(),
     })

--- a/apps/agents/agent-tauri/src-tauri/src/events.rs
+++ b/apps/agents/agent-tauri/src-tauri/src/events.rs
@@ -92,7 +92,7 @@ fn start_discovery(name: &str, port: u16) -> Option<DiscoveryServer> {
         id,
         name: name.to_string(),
         platform: std::env::consts::OS.to_string(),
-        version: env!("CARGO_PKG_VERSION").to_string(),
+        version: env!("CAPYDEPLOY_VERSION").to_string(),
         port,
         ips: vec![],
     };
@@ -138,7 +138,7 @@ async fn emit_status(handle: &AppHandle, state: &AgentState) {
         running: true,
         name: config.name.clone(),
         platform: std::env::consts::OS.into(),
-        version: env!("CARGO_PKG_VERSION").into(),
+        version: env!("CAPYDEPLOY_VERSION").into(),
         port,
         ips,
         accept_connections: state.accept_connections.load(Ordering::Relaxed),

--- a/apps/agents/agent-tauri/src-tauri/src/handler.rs
+++ b/apps/agents/agent-tauri/src-tauri/src/handler.rs
@@ -234,7 +234,7 @@ impl Handler for TauriAgentHandler {
                 id: generate_agent_id(&config.name),
                 name: config.name.clone(),
                 platform: std::env::consts::OS.into(),
-                version: env!("CARGO_PKG_VERSION").into(),
+                version: env!("CAPYDEPLOY_VERSION").into(),
                 accept_connections: self.state.accept_connections.load(Ordering::Relaxed),
                 supported_image_formats: vec![
                     "png".into(),
@@ -1147,7 +1147,7 @@ impl TauriAgentHandler {
         let config = self.state.config.lock().await;
         let resp = messages::AgentStatusResponse {
             name: config.name.clone(),
-            version: env!("CARGO_PKG_VERSION").into(),
+            version: env!("CAPYDEPLOY_VERSION").into(),
             platform: std::env::consts::OS.into(),
             accept_connections: self.state.accept_connections.load(Ordering::Relaxed),
             telemetry_enabled: config.telemetry_enabled,
@@ -1196,7 +1196,7 @@ impl TauriAgentHandler {
             running: true,
             name: config.name.clone(),
             platform: std::env::consts::OS.into(),
-            version: env!("CARGO_PKG_VERSION").into(),
+            version: env!("CAPYDEPLOY_VERSION").into(),
             port,
             ips: local_ips(),
             accept_connections: self.state.accept_connections.load(Ordering::Relaxed),

--- a/apps/agents/agent-tauri/src-tauri/tauri.conf.json
+++ b/apps/agents/agent-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri-v2-nightly-schema/main/tauri.conf.json",
   "productName": "CapyDeploy Agent",
-  "version": "0.1.0",
+  "version": "0.8.1",
   "identifier": "com.capydeploy.agent",
   "build": {
     "beforeDevCommand": "cd ../frontend && bun run dev",

--- a/apps/hub-tauri/src-tauri/build.rs
+++ b/apps/hub-tauri/src-tauri/build.rs
@@ -1,3 +1,21 @@
 fn main() {
+    // Read project version from workspace VERSION file
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let version_path = std::path::Path::new(&manifest_dir)
+        .ancestors()
+        .find_map(|p| {
+            let candidate = p.join("VERSION");
+            candidate.exists().then_some(candidate)
+        })
+        .expect("Could not find VERSION file in parent directories");
+
+    let version = std::fs::read_to_string(&version_path)
+        .expect("Failed to read VERSION file")
+        .trim()
+        .to_string();
+
+    println!("cargo:rustc-env=CAPYDEPLOY_VERSION={version}");
+    println!("cargo:rerun-if-changed={}", version_path.display());
+
     tauri_build::build()
 }

--- a/apps/hub-tauri/src-tauri/src/commands/settings.rs
+++ b/apps/hub-tauri/src-tauri/src/commands/settings.rs
@@ -10,7 +10,7 @@ use crate::types::{HubInfoDto, VersionInfoDto};
 #[tauri::command]
 pub async fn get_version() -> Result<VersionInfoDto, String> {
     Ok(VersionInfoDto {
-        version: env!("CARGO_PKG_VERSION").into(),
+        version: env!("CAPYDEPLOY_VERSION").into(),
         commit: option_env!("CAPYDEPLOY_COMMIT").unwrap_or("dev").into(),
         build_date: option_env!("CAPYDEPLOY_BUILD_DATE").unwrap_or("").into(),
     })

--- a/apps/hub-tauri/src-tauri/src/lib.rs
+++ b/apps/hub-tauri/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ pub fn run() {
 
     let identity = capydeploy_hub_connection::HubIdentity {
         name: cfg.name.clone(),
-        version: env!("CARGO_PKG_VERSION").into(),
+        version: env!("CAPYDEPLOY_VERSION").into(),
         platform: std::env::consts::OS.into(),
         hub_id: cfg.hub_id.clone(),
     };

--- a/apps/hub-tauri/src-tauri/tauri.conf.json
+++ b/apps/hub-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri-v2-nightly-schema/main/tauri.conf.json",
   "productName": "CapyDeploy Hub",
-  "version": "0.1.0",
+  "version": "0.8.1",
   "identifier": "com.capydeploy.hub",
   "build": {
     "beforeDevCommand": "cd ../frontend && bun run dev",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,7 +17,10 @@
         { "type": "test", "section": "Tests" },
         { "type": "chore", "section": "Miscellaneous", "hidden": true }
       ],
-      "extra-files": []
+      "extra-files": [
+        { "type": "json", "path": "apps/hub-tauri/src-tauri/tauri.conf.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "apps/agents/agent-tauri/src-tauri/tauri.conf.json", "jsonpath": "$.version" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- **build.rs** in both Hub and Agent Tauri now reads the workspace `VERSION` file at compile time and exposes `CAPYDEPLOY_VERSION` env var
- All `env!("CARGO_PKG_VERSION")` replaced with `env!("CAPYDEPLOY_VERSION")` across both apps (11 occurrences)
- **release-please extra-files** configured to auto-update `tauri.conf.json` versions on each release
- Fixed current `tauri.conf.json` versions from `0.1.0` → `0.8.1`

## Test plan
- [x] `cargo check -p capydeploy-hub-tauri` — compiles OK
- [x] `cargo check -p capydeploy-agent-tauri` — compiles OK
- [x] Zero `CARGO_PKG_VERSION` matches in `apps/` after changes
- [ ] Verify displayed version in Hub UI settings
- [ ] Verify displayed version in Agent UI status

Closes #165