### PR TITLE
docs(site): agregar Cloudflare Web Analytics

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -9,5 +9,9 @@
   </main>
 
   {% include footer.html %}
+
+  <!-- Cloudflare Web Analytics -->
+  <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "91d5eeb110bb4a62a768cc7336b20b06"}'></script>
+  <!-- End Cloudflare Web Analytics -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Agrega Cloudflare Web Analytics al layout principal del sitio de documentación
- Permite trackear page views y visitas sin cookies ni tracking individual
- El snippet se carga con `defer` para no afectar el rendimiento de carga

## Test plan
- [ ] Verificar que el sitio carga correctamente después del deploy
- [ ] Confirmar que Cloudflare Web Analytics muestra datos en el dashboard