### PR TITLE
fix(ci): use native OS runners for Windows builds (MSVC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,63 +72,53 @@ jobs:
 
   rust-build:
     name: Build (${{ matrix.target }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: linux-amd64
-            rust_target: ""
-            bin_dir: target/release
+            os: ubuntu-latest
             hub_bin: capydeploy-hub-tauri
             agent_bin: capydeploy-agent-tauri
           - target: windows-amd64
-            rust_target: x86_64-pc-windows-gnu
-            bin_dir: target/x86_64-pc-windows-gnu/release
+            os: windows-latest
             hub_bin: capydeploy-hub-tauri.exe
             agent_bin: capydeploy-agent-tauri.exe
     steps:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rust_target }}
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
           key: ${{ matrix.target }}
 
-      - name: Install system dependencies
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev
-          if [ "${{ matrix.target }}" = "windows-amd64" ]; then
-            sudo apt-get install -y gcc-mingw-w64-x86-64
-          fi
 
       - uses: oven-sh/setup-bun@v2
 
       - name: Build frontends (required by tauri_build)
+        shell: bash
         run: |
           cd apps/hub-tauri/frontend && bun install && bun run build && cd ../../..
           cd apps/agents/agent-tauri/frontend && bun install && bun run build && cd ../../..
 
       - name: Build binaries
-        run: |
-          BUILD_CMD="cargo build --release -p capydeploy-hub-tauri -p capydeploy-agent-tauri"
-          if [ -n "${{ matrix.rust_target }}" ]; then
-            BUILD_CMD="$BUILD_CMD --target ${{ matrix.rust_target }}"
-          fi
-          $BUILD_CMD
+        run: cargo build --release -p capydeploy-hub-tauri -p capydeploy-agent-tauri
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.target }}
           path: |
-            ${{ matrix.bin_dir }}/${{ matrix.hub_bin }}
-            ${{ matrix.bin_dir }}/${{ matrix.agent_bin }}
+            target/release/${{ matrix.hub_bin }}
+            target/release/${{ matrix.agent_bin }}
           retention-days: 7
 
   wire-compat:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,19 +19,17 @@ permissions:
 jobs:
   build:
     name: Build (${{ matrix.target }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: linux-amd64
-            rust_target: ""
-            bin_dir: target/release
+            os: ubuntu-latest
             hub_bin: capydeploy-hub-tauri
             agent_bin: capydeploy-agent-tauri
           - target: windows-amd64
-            rust_target: x86_64-pc-windows-gnu
-            bin_dir: target/x86_64-pc-windows-gnu/release
+            os: windows-latest
             hub_bin: capydeploy-hub-tauri.exe
             agent_bin: capydeploy-agent-tauri.exe
     steps:
@@ -40,48 +38,40 @@ jobs:
           ref: ${{ inputs.tag_name }}
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rust_target }}
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
           key: ${{ matrix.target }}
 
-      - name: Install system dependencies
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev
-          if [ "${{ matrix.target }}" = "windows-amd64" ]; then
-            sudo apt-get install -y gcc-mingw-w64-x86-64
-          fi
 
       - uses: oven-sh/setup-bun@v2
 
       - name: Build frontends (required by tauri_build)
+        shell: bash
         run: |
           cd apps/hub-tauri/frontend && bun install && bun run build && cd ../../..
           cd apps/agents/agent-tauri/frontend && bun install && bun run build && cd ../../..
 
       - name: Build binaries
-        run: |
-          BUILD_CMD="cargo build --release -p capydeploy-hub-tauri -p capydeploy-agent-tauri"
-          if [ -n "${{ matrix.rust_target }}" ]; then
-            BUILD_CMD="$BUILD_CMD --target ${{ matrix.rust_target }}"
-          fi
-          $BUILD_CMD
+        run: cargo build --release -p capydeploy-hub-tauri -p capydeploy-agent-tauri
 
       - name: Upload Hub binary
         uses: actions/upload-artifact@v4
         with:
           name: hub-${{ matrix.target }}
-          path: ${{ matrix.bin_dir }}/${{ matrix.hub_bin }}
+          path: target/release/${{ matrix.hub_bin }}
 
       - name: Upload Agent binary
         uses: actions/upload-artifact@v4
         with:
           name: agent-${{ matrix.target }}
-          path: ${{ matrix.bin_dir }}/${{ matrix.agent_bin }}
+          path: target/release/${{ matrix.agent_bin }}
 
   appimage:
     name: AppImage

--- a/apps/agents/agent-tauri/src-tauri/tauri.conf.json
+++ b/apps/agents/agent-tauri/src-tauri/tauri.conf.json
@@ -32,7 +32,12 @@
     "icon": [
       "icons/icon.png",
       "icons/icon.ico"
-    ]
+    ],
+    "windows": {
+      "webviewInstallMode": {
+        "type": "skip"
+      }
+    }
   },
   "plugins": {
     "shell": {

--- a/apps/hub-tauri/src-tauri/tauri.conf.json
+++ b/apps/hub-tauri/src-tauri/tauri.conf.json
@@ -31,7 +31,12 @@
     "icon": [
       "icons/icon.png",
       "icons/icon.ico"
-    ]
+    ],
+    "windows": {
+      "webviewInstallMode": {
+        "type": "skip"
+      }
+    }
   },
   "plugins": {
     "shell": {

--- a/build_all.sh
+++ b/build_all.sh
@@ -248,10 +248,10 @@ APPRUN
 }
 
 # ============================================
-# [1/7] Check required tools
+# [1/6] Check required tools
 # ============================================
 
-echo -e "${YELLOW}[1/7]${NC} Checking required tools..."
+echo -e "${YELLOW}[1/6]${NC} Checking required tools..."
 echo
 
 if ! command -v cargo &> /dev/null; then
@@ -281,19 +281,19 @@ echo -e "  ${GREEN}All tools OK!${NC}"
 echo
 
 # ============================================
-# [2/7] Init submodules
+# [2/6] Init submodules
 # ============================================
 
-echo -e "${YELLOW}[2/7]${NC} Initializing submodules..."
+echo -e "${YELLOW}[2/6]${NC} Initializing submodules..."
 git submodule update --init --recursive
 echo -e "  ${GREEN}Done${NC}"
 echo
 
 # ============================================
-# [3/7] Build frontends
+# [3/6] Build frontends
 # ============================================
 
-echo -e "${YELLOW}[3/7]${NC} Building frontends..."
+echo -e "${YELLOW}[3/6]${NC} Building frontends..."
 echo
 
 build_frontend() {
@@ -325,10 +325,10 @@ fi
 echo
 
 # ============================================
-# [4/7] Build Linux (cargo)
+# [4/6] Build Linux (cargo)
 # ============================================
 
-echo -e "${YELLOW}[4/7]${NC} Building Linux binaries (cargo release)..."
+echo -e "${YELLOW}[4/6]${NC} Building Linux binaries (cargo release)..."
 echo
 
 if cargo build --release -p capydeploy-hub-tauri -p capydeploy-agent-tauri; then
@@ -346,39 +346,10 @@ fi
 echo
 
 # ============================================
-# [5/7] Cross-compile for Windows
+# [5/6] Generate AppImages
 # ============================================
 
-echo -e "${YELLOW}[5/7]${NC} Cross-compiling for Windows..."
-echo
-
-if rustup target list --installed 2>/dev/null | grep -q "x86_64-pc-windows-gnu" && \
-   command -v x86_64-w64-mingw32-gcc &> /dev/null; then
-    if cargo build --release --target x86_64-pc-windows-gnu \
-        -p capydeploy-hub-tauri -p capydeploy-agent-tauri 2>/dev/null; then
-        mkdir -p "$DIST_DIR/windows"
-        cp "target/x86_64-pc-windows-gnu/release/capydeploy-hub-tauri.exe" "$DIST_DIR/windows/"
-        cp "target/x86_64-pc-windows-gnu/release/capydeploy-agent-tauri.exe" "$DIST_DIR/windows/"
-        RESULTS[windows]="success"
-        echo -e "  ${GREEN}Windows binaries ready${NC}"
-    else
-        RESULTS[windows]="failed"
-        echo -e "  ${YELLOW}[WARN]${NC} Windows cross-compile failed"
-    fi
-else
-    RESULTS[windows]="skipped"
-    echo -e "  ${YELLOW}[INFO]${NC} Windows cross-compile not available"
-    echo "  Need: rustup target add x86_64-pc-windows-gnu"
-    echo "  Need: rpm-ostree install mingw64-gcc"
-fi
-
-echo
-
-# ============================================
-# [6/7] Generate AppImages
-# ============================================
-
-echo -e "${YELLOW}[6/7]${NC} Generating AppImages..."
+echo -e "${YELLOW}[5/6]${NC} Generating AppImages..."
 echo
 
 if [ "${RESULTS[linux]}" = "success" ]; then
@@ -404,10 +375,10 @@ fi
 echo
 
 # ============================================
-# [7/7] Build Decky plugin
+# [6/6] Build Decky plugin
 # ============================================
 
-echo -e "${YELLOW}[7/7]${NC} Building Decky plugin..."
+echo -e "${YELLOW}[6/6]${NC} Building Decky plugin..."
 echo
 
 if [ -f "apps/agents/decky/build.sh" ]; then
@@ -450,15 +421,6 @@ print_binary() {
 echo -e "${YELLOW}Linux:${NC}"
 print_binary "Hub" "$DIST_DIR/linux/capydeploy-hub-tauri"
 print_binary "Agent" "$DIST_DIR/linux/capydeploy-agent-tauri"
-
-# Windows
-echo -e "${YELLOW}Windows:${NC}"
-if [ "${RESULTS[windows]}" = "skipped" ]; then
-    echo -e "  ${YELLOW}–${NC} Skipped (no cross-compile toolchain)"
-else
-    print_binary "Hub" "$DIST_DIR/windows/capydeploy-hub-tauri.exe"
-    print_binary "Agent" "$DIST_DIR/windows/capydeploy-agent-tauri.exe"
-fi
 
 # AppImages
 echo -e "${YELLOW}AppImages:${NC}"


### PR DESCRIPTION
## Summary

- Replace MinGW cross-compilation with native MSVC builds on `windows-latest` runners
- Add `webviewInstallMode: skip` to both `tauri.conf.json` (WebView2 already bundled in Win10/11)
- Remove Windows cross-compile step from `build_all.sh` (now CI-only via native runner)

Closes #173

## Changes

| File | Change |
|------|--------|
| `ci.yml` | Matrix with `runs-on: ${{ matrix.os }}`, conditional Linux deps |
| `release.yml` | Same matrix change, unified `target/release/` paths |
| `build_all.sh` | Remove step 5 (cross-compile), renumber 7→6 steps |
| `tauri.conf.json` (x2) | Add `bundle.windows.webviewInstallMode.type: skip` |

## Test plan

- [ ] CI passes on both `ubuntu-latest` and `windows-latest`
- [ ] Windows binary links `WebView2Loader` statically (no DLL error)
- [ ] Linux build and AppImage generation unaffected