### PR TITLE
feat(docs): show release version in download cards

### DIFF
--- a/docs/install.html
+++ b/docs/install.html
@@ -44,7 +44,7 @@ title: Installation
         <div class="w-12 h-12 rounded-xl bg-blue-500/10 flex items-center justify-center mb-4">
           <svg class="w-6 h-6 text-blue-400" fill="currentColor" viewBox="0 0 24 24"><path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/></svg>
         </div>
-        <h3 class="text-lg font-semibold mb-2">Windows</h3>
+        <h3 class="text-lg font-semibold mb-2">Windows <span id="version-windows" class="text-xs font-normal text-blue-400/60"></span></h3>
         <p class="text-slate-400 text-sm mb-4 flex-1">Hub + Agent bundled in a single ZIP. Extract and run.</p>
         <div class="flex flex-wrap gap-2">
           <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/capydeploy-windows-amd64.zip" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-500/10 text-blue-400 text-xs font-medium hover:bg-blue-500/20 transition">
@@ -59,7 +59,7 @@ title: Installation
         <div class="w-12 h-12 rounded-xl bg-green-500/10 flex items-center justify-center mb-4">
           <svg class="w-6 h-6 text-green-400" fill="currentColor" viewBox="0 0 24 24"><path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.368 1.884 1.43.585.047 1.042-.245 1.484-.93.4-.644.752-1.474.939-2.386.029-.143.057-.26.127-.397.063-.119.185-.277.316-.333.349-.153.561-.347.672-.628.117-.282.127-.627.049-1.084-.058-.328-.63-1.256-.12-1.593.488-.31 1.44-1.147 1.852-2.238.191-.555.203-1.16.042-1.775-.162-.607-.543-1.233-.959-1.7-.816-.936-1.658-1.244-2.123-1.79-.455-.533-.636-1.15-.702-1.75-.065-.572.004-1.134-.074-1.7C17.1 1.894 14.897.003 12.504 0z"/></svg>
         </div>
-        <h3 class="text-lg font-semibold mb-2">Linux</h3>
+        <h3 class="text-lg font-semibold mb-2">Linux <span id="version-linux" class="text-xs font-normal text-green-400/60"></span></h3>
         <p class="text-slate-400 text-sm mb-4 flex-1">AppImages with auto-install support. One for each component.</p>
         <div class="flex flex-wrap gap-2">
           <a href="https://github.com/lobinuxsoft/capydeploy/releases/latest/download/CapyDeploy_Hub.AppImage" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-green-500/10 text-green-400 text-xs font-medium hover:bg-green-500/20 transition">
@@ -80,7 +80,7 @@ title: Installation
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/>
           </svg>
         </div>
-        <h3 class="text-lg font-semibold mb-2">Decky Plugin <span class="text-sm text-slate-500 font-normal">(Gaming Mode)</span></h3>
+        <h3 class="text-lg font-semibold mb-2">Decky Plugin <span class="text-sm text-slate-500 font-normal">(Gaming Mode)</span> <span id="version-decky" class="text-xs font-normal text-purple-400/60"></span></h3>
         <p class="text-slate-400 text-sm mb-4 flex-1">Alternative Agent inside <a href="https://github.com/SteamDeckHomebrew/decky-loader" class="text-purple-400 hover:underline">Decky Loader</a>. No Steam restart needed.</p>
         <div class="flex flex-wrap gap-2">
           <a href="https://github.com/lobinuxsoft/decky-capydeploy/releases/latest/download/CapyDeploy.zip" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-purple-500/10 text-purple-400 text-xs font-medium hover:bg-purple-500/20 transition">
@@ -278,3 +278,51 @@ cd apps/agents/agent-tauri && ./build.sh</code></pre>
     </div>
   </div>
 </section>
+
+<script>
+(function() {
+  var CACHE_KEY = 'capydeploy-versions';
+  var CACHE_TTL = 5 * 60 * 1000;
+
+  function setVersion(id, tag) {
+    var el = document.getElementById(id);
+    if (el && tag) el.textContent = tag;
+  }
+
+  function fetchAndCache() {
+    var cached = sessionStorage.getItem(CACHE_KEY);
+    if (cached) {
+      try {
+        var data = JSON.parse(cached);
+        if (Date.now() - data.ts < CACHE_TTL) {
+          setVersion('version-windows', data.main);
+          setVersion('version-linux', data.main);
+          setVersion('version-decky', data.decky);
+          return;
+        }
+      } catch(e) {}
+    }
+
+    var main = fetch('https://api.github.com/repos/lobinuxsoft/capydeploy/releases/latest')
+      .then(function(r) { return r.ok ? r.json() : null; })
+      .then(function(d) { return d ? d.tag_name : null; })
+      .catch(function() { return null; });
+
+    var decky = fetch('https://api.github.com/repos/lobinuxsoft/decky-capydeploy/releases/latest')
+      .then(function(r) { return r.ok ? r.json() : null; })
+      .then(function(d) { return d ? d.tag_name : null; })
+      .catch(function() { return null; });
+
+    Promise.all([main, decky]).then(function(results) {
+      setVersion('version-windows', results[0]);
+      setVersion('version-linux', results[0]);
+      setVersion('version-decky', results[1]);
+      sessionStorage.setItem(CACHE_KEY, JSON.stringify({
+        main: results[0], decky: results[1], ts: Date.now()
+      }));
+    });
+  }
+
+  fetchAndCache();
+})();
+</script>


### PR DESCRIPTION
## Summary
- Dynamic version badges on download cards fetched from GitHub API
- Windows/Linux show capydeploy release tag, Decky shows decky-capydeploy release tag
- 5-minute sessionStorage cache, silent fallback on API failure

Closes #188

## Test plan
- [ ] Verify version badges render on GitHub Pages
- [ ] Verify cache works (no duplicate API calls on reload)