### PR TITLE
fix(hub): generate UUID for new game setups to prevent wrong deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/hub-tauri/frontend/src/lib/components/GameSetupList.svelte
+++ b/apps/hub-tauri/frontend/src/lib/components/GameSetupList.svelte
@@ -203,7 +203,7 @@
 	</p>
 
 	<div class="space-y-2">
-		{#each $gameSetups as setup}
+		{#each $gameSetups as setup (setup.id)}
 			{@const artworkCount = countArtwork(setup)}
 			{@const isUploading = uploading === setup.id}
 			<div class="cd-section p-4">

--- a/apps/hub-tauri/src-tauri/Cargo.toml
+++ b/apps/hub-tauri/src-tauri/Cargo.toml
@@ -46,3 +46,4 @@ anyhow = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 base64 = { workspace = true }
 open = "5"
+uuid = { workspace = true }

--- a/apps/hub-tauri/src-tauri/src/commands/deploy.rs
+++ b/apps/hub-tauri/src-tauri/src/commands/deploy.rs
@@ -15,7 +15,13 @@ pub async fn get_game_setups(state: State<'_, HubState>) -> Result<Vec<GameSetup
 }
 
 #[tauri::command]
-pub async fn add_game_setup(state: State<'_, HubState>, setup: GameSetup) -> Result<(), String> {
+pub async fn add_game_setup(
+    state: State<'_, HubState>,
+    mut setup: GameSetup,
+) -> Result<(), String> {
+    if setup.id.is_empty() {
+        setup.id = uuid::Uuid::new_v4().to_string();
+    }
     let mut cfg = state.config.lock().await;
     cfg.game_setups.push(setup);
     cfg.save().map_err(|e| e.to_string())


### PR DESCRIPTION
## Summary

- Generate UUIDv4 in `add_game_setup` when the setup ID is empty, ensuring each game setup has a unique identifier
- Add keyed `{#each}` block in `GameSetupList.svelte` to prevent Svelte visual desync

## Root cause

New game setups were created with `id: ''` (empty string). Since all entries shared the same empty ID:
- `upload_game` used `.find(|s| s.id == id)` which always returned the **first** match — deploying the wrong game
- `remove_game_setup` used `.retain(|s| s.id != id)` which removed **all** entries with empty ID
- The Svelte `{#each}` loop had no key, tracking elements by index instead of identity

## Changes

| File | Change |
|------|--------|
| `deploy.rs` | Generate UUID when `setup.id` is empty in `add_game_setup` |
| `GameSetupList.svelte` | Add `(setup.id)` key to `{#each}` loop |
| `Cargo.toml` | Add `uuid` workspace dependency to hub-tauri |

## Test plan

- [ ] Add 3+ game setups in Upload Game tab
- [ ] Click upload on the last game → verify it deploys the correct one
- [ ] Delete a single game → verify only that game is removed
- [ ] Edit a game → verify the correct entry is updated
- [ ] Verify existing saved setups (with empty IDs from before the fix) still work after re-adding

Closes #197