### PR TITLE
feat(hub): detachable telemetry and console log windows

### DIFF
--- a/apps/hub-tauri/frontend/src/lib/popout.ts
+++ b/apps/hub-tauri/frontend/src/lib/popout.ts
@@ -1,0 +1,51 @@
+import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
+import { emit } from '@tauri-apps/api/event';
+
+export const POPOUT_LABELS = {
+	telemetry: 'popout-telemetry',
+	consolelog: 'popout-consolelog'
+} as const;
+
+interface PopoutConfig {
+	label: string;
+	title: string;
+	url: string;
+	width?: number;
+	height?: number;
+}
+
+export async function openPopout(config: PopoutConfig): Promise<void> {
+	const existing = await WebviewWindow.getByLabel(config.label);
+	if (existing) {
+		await existing.setFocus();
+		return;
+	}
+
+	new WebviewWindow(config.label, {
+		url: config.url,
+		title: config.title,
+		width: config.width ?? 600,
+		height: config.height ?? 500,
+		minWidth: 400,
+		minHeight: 300,
+		resizable: true,
+		decorations: true
+	});
+}
+
+export async function closePopout(label: string): Promise<void> {
+	const win = await WebviewWindow.getByLabel(label);
+	if (win) {
+		await win.close();
+	}
+}
+
+export async function closeAllPopouts(): Promise<void> {
+	await Promise.allSettled(
+		Object.values(POPOUT_LABELS).map((label) => closePopout(label))
+	);
+}
+
+export async function requestStateSync(): Promise<void> {
+	await emit('popout:request-state');
+}

--- a/apps/hub-tauri/frontend/src/routes/+page.svelte
+++ b/apps/hub-tauri/frontend/src/routes/+page.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
 	import { Tabs } from '$lib/components/ui';
-	import { ConnectionStatus, DeviceList, GameSetupList, InstalledGames, Settings, Telemetry, ConsoleLog } from '$lib/components';
+	import { ConnectionStatus, DeviceList, GameSetupList, InstalledGames, Settings } from '$lib/components';
 	import { connectionStatus } from '$lib/stores/connection';
 	import { telemetry } from '$lib/stores/telemetry';
 	import { consolelog } from '$lib/stores/consolelog';
 	import { EventsOn } from '$lib/wailsjs';
 	import { browser } from '$app/environment';
 	import type { TelemetryStatus, TelemetryData, ConsoleLogStatus, ConsoleLogBatch } from '$lib/types';
+	import { openPopout, closeAllPopouts, POPOUT_LABELS } from '$lib/popout';
+	import { emitTo } from '@tauri-apps/api/event';
+	import { get } from 'svelte/store';
+	import { Cpu, Terminal } from 'lucide-svelte';
 
 	// Tabs are dynamic based on connection status.
 	// "Upload Game" and "Installed Games" only appear when an agent is connected.
@@ -14,9 +18,7 @@
 		{ id: 'devices', label: 'Devices' },
 		...($connectionStatus.connected ? [
 			{ id: 'upload', label: 'Upload Game' },
-			{ id: 'games', label: 'Installed Games' },
-			{ id: 'telemetry', label: 'Telemetry' },
-			{ id: 'consolelog', label: 'Console' }
+			{ id: 'games', label: 'Installed Games' }
 		] : []),
 		{ id: 'settings', label: 'Settings' }
 	]);
@@ -31,6 +33,7 @@
 			if (!status.connected) {
 				telemetry.reset();
 				consolelog.reset();
+				closeAllPopouts();
 			}
 		});
 
@@ -50,12 +53,31 @@
 			consolelog.addBatch(event.entries, event.dropped);
 		});
 
+		// Respond to pop-out windows requesting current state
+		const unsubStateReq = EventsOn('popout:request-state', () => {
+			const telStatus = get(telemetry.status);
+			const telData = get(telemetry.data);
+			const clStatus = get(consolelog.status);
+			const clEntries = get(consolelog.entries);
+			const clDropped = get(consolelog.totalDropped);
+
+			for (const label of Object.values(POPOUT_LABELS)) {
+				emitTo(label, 'telemetry:status', telStatus);
+				if (telData) emitTo(label, 'telemetry:data', telData);
+				emitTo(label, 'consolelog:status', clStatus);
+				if (clEntries.length > 0) {
+					emitTo(label, 'consolelog:data', { entries: clEntries, dropped: clDropped });
+				}
+			}
+		});
+
 		return () => {
 			unsubConnection();
 			unsubTelStatus();
 			unsubTelData();
 			unsubClStatus();
 			unsubClData();
+			unsubStateReq();
 		};
 	});
 </script>
@@ -77,22 +99,44 @@
 
 	<!-- Main content -->
 	<div class="p-6">
-		<Tabs {tabs}>
-			{#snippet children(activeTab)}
-				{#if activeTab === 'devices'}
-					<DeviceList />
-				{:else if activeTab === 'upload'}
-					<GameSetupList />
-				{:else if activeTab === 'games'}
-					<InstalledGames />
-				{:else if activeTab === 'telemetry'}
-					<Telemetry />
-				{:else if activeTab === 'consolelog'}
-					<ConsoleLog />
-				{:else if activeTab === 'settings'}
-					<Settings />
-				{/if}
-			{/snippet}
-		</Tabs>
+		<div class="flex items-center gap-3 mb-4">
+			<div class="flex-1">
+				<Tabs {tabs}>
+					{#snippet children(activeTab)}
+						{#if activeTab === 'devices'}
+							<DeviceList />
+						{:else if activeTab === 'upload'}
+							<GameSetupList />
+						{:else if activeTab === 'games'}
+							<InstalledGames />
+						{:else if activeTab === 'settings'}
+							<Settings />
+						{/if}
+					{/snippet}
+				</Tabs>
+			</div>
+			{#if $connectionStatus.connected}
+				<div class="flex items-center gap-1 self-start">
+					<button
+						type="button"
+						onclick={() => openPopout({ label: POPOUT_LABELS.telemetry, title: 'CapyDeploy - Telemetry', url: '/telemetry' })}
+						class="inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-sm font-medium text-muted-foreground hover:bg-background/50 hover:text-foreground transition-all"
+						title="Open Telemetry window"
+					>
+						<Cpu class="w-4 h-4" />
+						Telemetry
+					</button>
+					<button
+						type="button"
+						onclick={() => openPopout({ label: POPOUT_LABELS.consolelog, title: 'CapyDeploy - Console Log', url: '/consolelog' })}
+						class="inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-sm font-medium text-muted-foreground hover:bg-background/50 hover:text-foreground transition-all"
+						title="Open Console Log window"
+					>
+						<Terminal class="w-4 h-4" />
+						Console
+					</button>
+				</div>
+			{/if}
+		</div>
 	</div>
 </div>

--- a/apps/hub-tauri/frontend/src/routes/consolelog/+page.svelte
+++ b/apps/hub-tauri/frontend/src/routes/consolelog/+page.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import { ConsoleLog } from '$lib/components';
+	import { consolelog } from '$lib/stores/consolelog';
+	import { EventsOn } from '$lib/wailsjs';
+	import { browser } from '$app/environment';
+	import { getCurrentWindow } from '@tauri-apps/api/window';
+	import { RefreshCw } from 'lucide-svelte';
+	import { requestStateSync } from '$lib/popout';
+	import type { ConsoleLogStatus, ConsoleLogBatch, ConnectionStatus } from '$lib/types';
+
+	function refresh() {
+		consolelog.clear();
+		requestStateSync();
+	}
+
+	$effect(() => {
+		if (!browser) return;
+
+		// Request current state from main window on mount
+		requestStateSync();
+
+		const unsubConnection = EventsOn('connection:changed', (status: ConnectionStatus) => {
+			if (!status.connected) {
+				getCurrentWindow().close();
+			}
+		});
+
+		const unsubClStatus = EventsOn('consolelog:status', (event: ConsoleLogStatus) => {
+			consolelog.status.set(event);
+		});
+
+		const unsubClData = EventsOn('consolelog:data', (event: ConsoleLogBatch) => {
+			consolelog.addBatch(event.entries, event.dropped);
+		});
+
+		return () => {
+			unsubConnection();
+			unsubClStatus();
+			unsubClData();
+		};
+	});
+</script>
+
+<div class="min-h-screen text-foreground p-4">
+	<div class="flex items-center justify-between mb-4">
+		<h2 class="text-sm font-medium text-muted-foreground">Console Log</h2>
+		<button
+			type="button"
+			onclick={refresh}
+			class="p-1.5 rounded hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
+			title="Refresh data"
+		>
+			<RefreshCw class="w-4 h-4" />
+		</button>
+	</div>
+	<ConsoleLog />
+</div>

--- a/apps/hub-tauri/frontend/src/routes/telemetry/+page.svelte
+++ b/apps/hub-tauri/frontend/src/routes/telemetry/+page.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { Telemetry } from '$lib/components';
+	import { telemetry } from '$lib/stores/telemetry';
+	import { EventsOn } from '$lib/wailsjs';
+	import { browser } from '$app/environment';
+	import { getCurrentWindow } from '@tauri-apps/api/window';
+	import { RefreshCw } from 'lucide-svelte';
+	import { requestStateSync } from '$lib/popout';
+	import type { TelemetryStatus, TelemetryData, ConnectionStatus } from '$lib/types';
+
+	$effect(() => {
+		if (!browser) return;
+
+		// Request current state from main window on mount
+		requestStateSync();
+
+		const unsubConnection = EventsOn('connection:changed', (status: ConnectionStatus) => {
+			if (!status.connected) {
+				getCurrentWindow().close();
+			}
+		});
+
+		const unsubTelStatus = EventsOn('telemetry:status', (event: TelemetryStatus) => {
+			telemetry.status.set(event);
+		});
+
+		const unsubTelData = EventsOn('telemetry:data', (event: TelemetryData) => {
+			telemetry.data.set(event);
+		});
+
+		return () => {
+			unsubConnection();
+			unsubTelStatus();
+			unsubTelData();
+		};
+	});
+</script>
+
+<div class="min-h-screen text-foreground p-4">
+	<div class="flex items-center justify-between mb-4">
+		<h2 class="text-sm font-medium text-muted-foreground">Telemetry</h2>
+		<button
+			type="button"
+			onclick={() => requestStateSync()}
+			class="p-1.5 rounded hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
+			title="Refresh data"
+		>
+			<RefreshCw class="w-4 h-4" />
+		</button>
+	</div>
+	<Telemetry />
+</div>

--- a/apps/hub-tauri/src-tauri/capabilities/default.json
+++ b/apps/hub-tauri/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:webview:allow-create-webview-window",
     "shell:allow-open",
     "dialog:allow-open",
     "dialog:allow-save"

--- a/apps/hub-tauri/src-tauri/capabilities/popout.json
+++ b/apps/hub-tauri/src-tauri/capabilities/popout.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nicedoc/tauri-v2-nightly-schema/main/capability.json",
+  "identifier": "popout",
+  "description": "Capabilities for detachable telemetry and console log windows",
+  "windows": ["popout-telemetry", "popout-consolelog"],
+  "permissions": [
+    "core:default",
+    "core:window:allow-close",
+    "core:window:allow-set-always-on-top",
+    "core:window:allow-set-focus",
+    "core:webview:allow-create-webview-window"
+  ]
+}


### PR DESCRIPTION
## Summary
- Telemetry and Console Log are now separate windows opened via buttons in the main tab bar instead of inline tabs
- Each pop-out window syncs current state from the main window on open and auto-closes on agent disconnect
- Added refresh button and inter-window state sync via Tauri events

## Test plan
- [x] Connect agent, click Telemetry button → separate window opens with live data
- [x] Same for Console Log
- [x] Disconnect agent → both pop-out windows close automatically
- [x] Click button twice → focuses existing window instead of opening duplicate
- [x] Refresh button re-syncs data from main window
- [x] `bun run check` passes with 0 errors
- [x] `cargo check` passes

Closes #106