### PR TITLE
fix: escape base64 data in CEF JavaScript evaluation

### DIFF
--- a/crates/steam/src/cef.rs
+++ b/crates/steam/src/cef.rs
@@ -203,7 +203,8 @@ impl CefClient {
         self.clear_custom_artwork(app_id, asset_type).await?;
 
         let js = format!(
-            r#"SteamClient.Apps.SetCustomArtworkForApp({app_id}, "{base64_data}", "png", {asset_type})"#,
+            "SteamClient.Apps.SetCustomArtworkForApp({app_id}, {}, \"png\", {asset_type})",
+            js_string(base64_data),
         );
         self.evaluate_void(&js).await
     }


### PR DESCRIPTION
## Summary
- Use `js_string()` helper for `base64_data` in `CefClient::set_custom_artwork()` to prevent JavaScript injection via crafted artwork data
- All other CEF methods (`add_shortcut`, `set_shortcut_name`, etc.) already used this helper correctly — this was the only one missed

Closes #231

## Related
- Decky submodule fix (timing-safe token comparison): lobinuxsoft/decky-capydeploy#20

## Test plan
- [x] `cargo check -p capydeploy-steam` compiles
- [x] `cargo test -p capydeploy-steam` — 32/32 tests pass
- [ ] Verify custom artwork still applies correctly in Steam