### PR TITLE
ci: bump GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Rust Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -47,7 +47,7 @@ jobs:
     name: Rust Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -86,7 +86,7 @@ jobs:
             hub_bin: capydeploy-hub-tauri.exe
             agent_bin: capydeploy-agent-tauri.exe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -113,7 +113,7 @@ jobs:
         run: cargo build --release -p capydeploy-hub-tauri -p capydeploy-agent-tauri
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-${{ matrix.target }}
           path: |
@@ -125,7 +125,7 @@ jobs:
     name: Frontend checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             hub_bin: capydeploy-hub-tauri.exe
             agent_bin: capydeploy-agent-tauri.exe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag_name }}
 
@@ -62,13 +62,13 @@ jobs:
         run: cargo build --release -p capydeploy-hub-tauri -p capydeploy-agent-tauri
 
       - name: Upload Hub binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hub-${{ matrix.target }}
           path: target/release/${{ matrix.hub_bin }}
 
       - name: Upload Agent binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agent-${{ matrix.target }}
           path: target/release/${{ matrix.agent_bin }}
@@ -78,18 +78,18 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag_name }}
 
       - name: Download Hub Linux binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: hub-linux-amd64
           path: artifacts/hub
 
       - name: Download Agent Linux binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: agent-linux-amd64
           path: artifacts/agent
@@ -415,7 +415,7 @@ jobs:
           ARCH=x86_64 ./appimagetool agent.AppDir CapyDeploy_Agent.AppImage
 
       - name: Upload AppImages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: appimages
           path: |
@@ -427,13 +427,13 @@ jobs:
     needs: [build, appimage]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag_name }}
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8

Node.js 20 actions are deprecated (forced Node.js 24 default from June 2nd 2026, Node.js 20 removed from runners September 16th 2026). These bumps move to the Node.js 24 versions, eliminating the deprecation warnings in CI.

Affects: `ci.yml`, `release.yml`. `release-please.yml` doesn't use any of the affected actions.

## Test plan
- [ ] CI passes on this PR (validates checkout + upload-artifact work)
- [ ] Next release validates download-artifact + full release pipeline