### PR TITLE
fix(file-ops): use sort_by_key to satisfy clippy 1.95 lint

### DIFF
--- a/crates/file-ops/src/browse.rs
+++ b/crates/file-ops/src/browse.rs
@@ -56,7 +56,7 @@ pub fn list_directory(path: &Path) -> Result<Vec<DirEntry>, String> {
         })
         .collect();
 
-    result.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    result.sort_by_key(|entry| entry.name.to_lowercase());
 
     Ok(result)
 }


### PR DESCRIPTION
## Summary

Unbreaks CI after GitHub runners updated to Rust 1.95 stable, which introduced the `unnecessary_sort_by` clippy lint.

## The problem

`crates/file-ops/src/browse.rs:59` was using `sort_by` with a case-insensitive comparator. Rust 1.95's new clippy flags this as replaceable with the lighter `sort_by_key`. Since CI enforces `-D warnings`, every PR against `development` breaks once the runner pulls 1.95.

Hit while trying to merge #237 — Rust Lint was the only failing check, even though that PR was a one-line submodule pointer bump.

## The fix

```diff
- result.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+ result.sort_by_key(|entry| entry.name.to_lowercase());
```

Mechanical substitution suggested by clippy itself. Semantically identical: both sort case-insensitively by `entry.name`.

## Test plan

- [x] `cargo check -p capydeploy-file-ops` passes locally
- [ ] CI green on Rust 1.95 (will validate once workflows run)
- [ ] #237 can be rebased and will no longer be blocked by this check