### PR TITLE
chore: merge development into master for release

### DIFF
--- a/crates/file-ops/src/browse.rs
+++ b/crates/file-ops/src/browse.rs
@@ -56,7 +56,7 @@ pub fn list_directory(path: &Path) -> Result<Vec<DirEntry>, String> {
         })
         .collect();
 
-    result.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    result.sort_by_key(|entry| entry.name.to_lowercase());
 
     Ok(result)
 }


### PR DESCRIPTION
## Summary

Promotes `development` to `master` so release-please can tag a new version. Aggregates every change merged to `development` since the last release.

## Changes included (since last release tag)

- **feat(decky): bump plugin to v1.1.0 with persistent progress visibility** (#237) — resolves #230
- **fix(file-ops): use sort_by_key to satisfy clippy 1.95 unnecessary_sort_by lint** (#238)

## Release impact

Once merged, release-please will detect the `feat:` and `fix:` commits and open a release PR bumping to the next MINOR version with the updated decky submodule pointer. After that release PR is merged, new Hub/Agent AppImages will be built and uploaded as GitHub Release assets.