### PR TITLE
chore: merge development into master for release

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -581,40 +581,58 @@ echo
 echo "Output directory: $DIST_DIR"
 echo
 
-# Helper to print file size
-print_binary() {
+# Report a step's outcome. Trusts the RESULTS map first so stale artifacts
+# from earlier (successful) runs cannot mask a failure in the current run.
+#
+# Usage: check_artifact <label> <path> <status> [size_unit]
+#   status: "success" | "failed" | "skipped"
+#   size_unit: "MB" (default) or "KB"
+check_artifact() {
     local label="$1"
     local path="$2"
-    if [ -f "$path" ]; then
-        local size
-        size=$(stat -c%s "$path" 2>/dev/null || echo "0")
-        local size_mb=$((size / 1048576))
-        echo -e "  ${GREEN}✓${NC} $label: ${size_mb} MB"
-    else
-        echo -e "  ${RED}✗${NC} $label: NOT FOUND"
+    local status="$3"
+    local size_unit="${4:-MB}"
+
+    if [ "$status" = "failed" ]; then
+        echo -e "  ${RED}✗${NC} $label: BUILD FAILED"
+        return
     fi
+    if [ "$status" = "skipped" ]; then
+        echo -e "  ${YELLOW}⊘${NC} $label: skipped"
+        return
+    fi
+
+    # Status is "success" — verify the expected artifact actually exists.
+    if [ -z "$path" ] || [ ! -f "$path" ]; then
+        echo -e "  ${RED}✗${NC} $label: MISSING (reported success but artifact not found)"
+        return
+    fi
+
+    local size
+    size=$(stat -c%s "$path" 2>/dev/null || echo "0")
+    local display
+    if [ "$size_unit" = "KB" ]; then
+        display="$((size / 1024)) KB"
+    else
+        display="$((size / 1048576)) MB"
+    fi
+    echo -e "  ${GREEN}✓${NC} $label: $display"
 }
 
 # Linux
 echo -e "${YELLOW}Linux:${NC}"
-print_binary "Hub" "$DIST_DIR/linux/capydeploy-hub-tauri"
-print_binary "Agent" "$DIST_DIR/linux/capydeploy-agent-tauri"
+check_artifact "Hub" "$DIST_DIR/linux/capydeploy-hub-tauri" "${RESULTS[linux]}"
+check_artifact "Agent" "$DIST_DIR/linux/capydeploy-agent-tauri" "${RESULTS[linux]}"
 
 # AppImages
 echo -e "${YELLOW}AppImages:${NC}"
-print_binary "Hub" "$DIST_DIR/appimage/CapyDeploy_Hub.AppImage"
-print_binary "Agent" "$DIST_DIR/appimage/CapyDeploy_Agent.AppImage"
+check_artifact "Hub" "$DIST_DIR/appimage/CapyDeploy_Hub.AppImage" "${RESULTS[appimage_hub]}"
+check_artifact "Agent" "$DIST_DIR/appimage/CapyDeploy_Agent.AppImage" "${RESULTS[appimage_agent]}"
 
 # Decky
 echo -e "${YELLOW}Decky:${NC}"
 DECKY_ZIP=$(find "$DIST_DIR/decky" -name "*.zip" 2>/dev/null | head -1)
-if [ -n "$DECKY_ZIP" ] && [ -f "$DECKY_ZIP" ]; then
-    SIZE=$(stat -c%s "$DECKY_ZIP" 2>/dev/null || echo "0")
-    SIZE_KB=$((SIZE / 1024))
-    echo -e "  ${GREEN}✓${NC} Plugin: ${SIZE_KB} KB"
-else
-    echo -e "  ${RED}✗${NC} Plugin: NOT FOUND"
-fi
+check_artifact "Plugin" "$DECKY_ZIP" "${RESULTS[decky]}" KB
 
 echo
 echo "Done!"

--- a/build_all.sh
+++ b/build_all.sh
@@ -635,4 +635,20 @@ DECKY_ZIP=$(find "$DIST_DIR/decky" -name "*.zip" 2>/dev/null | head -1)
 check_artifact "Plugin" "$DECKY_ZIP" "${RESULTS[decky]}" KB
 
 echo
+
+# Propagate failures: exit non-zero so CI and shell callers catch the
+# failure. Previously the script always returned 0, even when steps like
+# the Decky plugin build were marked as failed in RESULTS.
+failed_steps=()
+for step in "${!RESULTS[@]}"; do
+    if [ "${RESULTS[$step]}" = "failed" ]; then
+        failed_steps+=("$step")
+    fi
+done
+
+if [ ${#failed_steps[@]} -gt 0 ]; then
+    echo -e "${RED}Build finished with ${#failed_steps[@]} failed step(s): ${failed_steps[*]}${NC}"
+    exit 1
+fi
+
 echo "Done!"


### PR DESCRIPTION
## Summary

Promotes `development` to `master` so release-please can tag a new PATCH version.

## Changes included (since v1.1.0)

- **fix(build): summary in build_all.sh trusts RESULTS instead of filesystem** (#242)
- **fix(build): exit build_all.sh with non-zero code when any step fails** (#242)

Closes #241 when merged.

## Release impact

Two `fix:` commits → release-please will bump to **v1.1.1** (PATCH) and rebuild the Hub/Agent AppImages + Linux/Windows binaries for the GitHub Release.